### PR TITLE
fix createTeamNamespaces

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 8.2.6
+version: 8.2.7
 appVersion: 5.6.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/templates/web-rolebinding.yaml
+++ b/templates/web-rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.web.enabled -}}
 {{- if .Values.rbac.create -}}
-{{- if .Values.concourse.web.kubernetes.enabled -}}
+{{- if and .Values.concourse.web.kubernetes.enabled .Values.concourse.web.kubernetes.createTeamNamespaces -}}
 {{- range .Values.concourse.web.kubernetes.teams }}
 ---
 apiVersion: rbac.authorization.k8s.io/{{ $.Values.rbac.apiVersion }}


### PR DESCRIPTION
The optional creation of team namespaces was not very optional, as the web rolebindings hardcoded assumed their presence. This commit fixes this.

Fixes helm/charts#18008
Fixes concourse/concourse-chart#3