### PR TITLE
rename chart name to concourse-chart

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: concourse
+name: concourse-chart
 version: 8.2.6
 appVersion: 5.6.0
 description: Concourse is a simple and scalable CI system.


### PR DESCRIPTION
rename it due to the consistency of folder name and chart name.

when we run the command under `concourse-chart` directory:
```
helm lint .
```
it does require the folder name and chart name to be identical. here is the error message when they mismatched.
```
==> Linting .
[ERROR] Chart.yaml: directory name (concourse-chart) and chart name (concourse) must be the same

Error: 1 chart(s) linted, 1 chart(s) failed
```

This PR is going to fix this issue.

Signed-off-by: Bin Ju <bju@pivotal.io>