### PR TITLE
Add CONCOURSE_GARDEN_REQUEST_TIMEOUT config

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: concourse
-version: 8.2.6
-appVersion: 5.6.0
+version: 8.3.0
+appVersion: 5.7.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479
 keywords:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `imageDigest` | Specific image digest to use in place of a tag. | `nil` |
 | `imagePullPolicy` | Concourse image pull policy | `IfNotPresent` |
 | `imagePullSecrets` | Array of imagePullSecrets in the namespace for pulling images | `[]` |
-| `imageTag` | Concourse image version | `5.6.0` |
+| `imageTag` | Concourse image version | `5.7.1` |
 | `image` | Concourse image | `concourse/concourse` |
 | `nameOverride` | Provide a name in place of `concourse` for `app:` labels | `nil` |
 | `persistence.enabled` | Enable Concourse persistence using Persistent Volume Claims | `true` |

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -263,6 +263,10 @@ spec:
             - name: CONCOURSE_MAX_ACTIVE_TASKS_PER_WORKER
               value: {{ .Values.concourse.web.limitActiveTasks | quote }}
             {{- end}}
+            {{- if .Values.concourse.web.gardenRequestTimeout }}
+            - name: CONCOURSE_GARDEN_REQUEST_TIMEOUT
+              value: {{ .Values.concourse.web.gardenRequestTimeout | quote }}
+            {{- end }}
             {{- if .Values.concourse.web.baggageclaimResponseHeaderTimeout }}
             - name: CONCOURSE_BAGGAGECLAIM_RESPONSE_HEADER_TIMEOUT
               value: {{ .Values.concourse.web.baggageclaimResponseHeaderTimeout | quote }}

--- a/templates/worker-statefulset.yaml
+++ b/templates/worker-statefulset.yaml
@@ -209,6 +209,10 @@ spec:
             - name: CONCOURSE_GARDEN_DNS_PROXY_ENABLE
               value: {{ .Values.concourse.worker.garden.dnsProxyEnable | quote }}
             {{- end }}
+            {{- if .Values.concourse.worker.garden.requestTimeout }}
+            - name: CONCOURSE_GARDEN_REQUEST_TIMEOUT
+              value: {{ .Values.concourse.worker.garden.requestTimeout | quote }}
+            {{- end }}
             {{- if .Values.concourse.worker.baggageclaim.logLevel }}
             - name: CONCOURSE_BAGGAGECLAIM_LOG_LEVEL
               value: {{ .Values.concourse.worker.baggageclaim.logLevel | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -19,7 +19,7 @@ image: concourse/concourse
 ##      of `concourse/concourse`.
 ## Ref: https://hub.docker.com/r/concourse/concourse/tags/
 ##
-imageTag: "5.6.0"
+imageTag: "5.7.1"
 
 ## Specific image digest to use in place of a tag.
 ## Ref: https://kubernetes.io/docs/concepts/configuration/overview/#container-images
@@ -238,6 +238,10 @@ concourse:
     ## ref: https://concourse-ci.org/container-placement.html#limit-active-tasks-strategy
     ##
     limitActiveTasks:
+
+    ## How long to wait for requests to Garden to complete. 0 means no timeout.
+    ##
+    gardenRequestTimeout:
 
     ## How long to wait for Baggageclaim to send the response header.
     ##
@@ -1214,6 +1218,10 @@ concourse:
       ## Use the insecure Houdini Garden backend.
       ##
       useHoudini:
+
+      ## How long to wait for requests to Garden to complete. 0 means no timeout.
+      ##
+      requestTimeout:
 
     baggageclaim:
       ## Minimum level of logs to see. Possible values: debug, info, error


### PR DESCRIPTION
* In 5.7.1, we added this configuration option as part of
[#4707](https://github.com/concourse/concourse/pull/4707)

Co-authored-by: Ciro S. Costa
Signed-off-by: Denise Yu <dyu@pivotal.io>