### PR TITLE
Update readme include concourse repo and updated install location tldr

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 ## TL;DR;
 
 ```console
-$ helm install stable/concourse
+$ helm repo add concourse https://concourse-charts.storage.googleapis.com/
+$ helm install concourse/concourse
 ```
 
 


### PR DESCRIPTION
This updates the tldr with the following:

* Repo add command (stable is being deprecated)
* Updated the install to point to ```concourse/concourse```