### PR TITLE
Add PR template and Code of Conduct

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,9 +25,7 @@ Fixes # .
 > Are the following items included as part of this PR? Please delete checkbox items that don't apply.
 - [ ] Bumped chart version in `chart.yml` (**required**)
   - [ ] If a major bump, update `CHANGELOG.md`
-- [ ] Update app version in `chart.yml`
-- [ ] Update image tag in `values.yml`
-- [ ] Update image tag in `README.md`
+- [ ] Variables are documented in the `README.md`
 
 
 # Reviewer Checklist

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+> Please remove all the lines starting with '>'
+> Hi there! Thanks for submitting a pull request to the Concourse Helm chart!
+> If you haven't already, please take a look at our [Code of Conduct](https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md).
+
+> To help us review your PR, please fill in the following information.
+> Feel free to delete any sections not applicable to your pull request.
+
+# Existing Issue
+> Is there an existing issue related to this PR? Fill in the issue number as follows: Fixes #1234.
+
+Fixes # .
+
+# Why do we need this PR?
+> No issue number? Please give us a few lines of context describing the need for this PR.
+
+
+# Changes proposed in this pull request
+> What are the changes included in this PR? Feel free to add as many lines as needed below.
+
+* 
+* 
+*
+
+# Contributor Checklist
+> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
+- [ ] Bumped chart version in `chart.yml` (**required**)
+  - [ ] If a major bump, update `CHANGELOG.md`
+- [ ] Update app version in `chart.yml`
+- [ ] Update image tag in `values.yml`
+- [ ] Update image tag in `README.md`
+
+
+# Reviewer Checklist
+> This section is intended for the core maintainers only, to track review progress. Please do not
+> fill out this section.
+- [ ] Code reviewed
+- [ ] Topgun tests run

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at concourse@pivotal.io . All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org


### PR DESCRIPTION
Until we get more automation around checking the PR's, similar to what
`helm/charts` has, this PR template should ease the burden of reminding
others what needs to be updated when updating the helm chart.

Signed-off-by: Taylor Silva <tsilva@pivotal.io>