### PR TITLE
worker: add hard anti affinity labels config

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 8.4.0
+version: 8.5.0
 appVersion: 5.7.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `worker.enabled` | Enable or disable the worker component. You should set postgres.enabled=false in order not to get an unnecessary Postgres chart deployed | `true` |
 | `worker.env` | Configure additional environment variables for the worker container(s) | `[]` |
 | `worker.hardAntiAffinity` | Should the workers be forced (as opposed to preferred) to be on different nodes? | `false` |
+| `worker.hardAntiAffinityLabels` | Set of labels used for hard anti affinity rule | `{}` |
 | `worker.keySecretsPath` | Specify the mount directory of the worker keys secrets | `/concourse-keys` |
 | `worker.livenessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded | `5` |
 | `worker.livenessProbe.httpGet.path` | Path to access on the HTTP server when performing the healthcheck | `/` |

--- a/templates/worker-statefulset.yaml
+++ b/templates/worker-statefulset.yaml
@@ -299,8 +299,12 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
+{{- if .Values.worker.hardAntiAffinityLabels }}
+{{ toYaml .Values.worker.hardAntiAffinityLabels | indent 16 }}
+{{- else }}
                 app: {{ template "concourse.worker.fullname" . }}
                 release: {{ .Release.Name | quote }}
+{{- end }}
             topologyKey: kubernetes.io/hostname
           {{- else }}
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/values.yaml
+++ b/values.yaml
@@ -1695,6 +1695,15 @@ worker:
   ##
   hardAntiAffinity: false
 
+  ## Set of labels to use in the hard anti affinity rule.
+  ##
+  ## Example:
+  ##   hardAntiAffinity: true
+  ##   hardAntiAffinityLabels:
+  ##     application: concourse
+  ##
+  hardAntiAffinityLabels: {}
+
   ## Tolerations for the worker nodes.
   ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##


### PR DESCRIPTION
### Why do we need this PR?

Previously, there was no way of having two releases of `worker` sharing
the same set of labels in their hard anti affinity rules given that we'd
always put a set that's release specific.

That meant that if one had a set of workers deployed through a release,
say, `release-1`, and another set of workers deployed through another
release, say, `release-2`, these would never be able to leverage the
same set of labels in their anti affinity rules as they'd have `release`
and `app` (label keys) set with values that would match `release-1` and
`release-2`.

The implication of that is that it becomes impossible guarantee the
inability of placing two concourse workers in the same node (on a shared
pool).

With the addition of `worker.hardAntiAffinityLabels` one is now able to
customize that set.

For instance:

```
helm template \
	--set worker.hardAntiAffinity=true \
	--set worker.hardAntiAffinityLabels.foo=bar . \
	| ag -A5 requiredDuring

          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchLabels:
                foo: bar

            topologyKey: kubernetes.io/hostname
```
```
helm template \
	--set worker.hardAntiAffinity=true . \
	| ag -A5 requiredDuring

          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchLabels:
                app: release-name-worker
                release: "release-name"
            topologyKey: kubernetes.io/hostname
```


### Changes proposed in this pull request

- add `worker.hardAntiAffinityLabels` configuration
- bump minor (new feature)

### Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Bumped chart version in `chart.yml` (**required**)
  - ~If a major bump, update `CHANGELOG.md`~ not a major
- [x] Variables are documented in the `README.md`


### Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
