### PR TITLE
Add microsoft auth and conjur creds manager configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ The following table lists the configurable parameters of the Concourse chart and
 | `secrets.cfCaCert` | CA certificate for cf auth provider | `nil` |
 | `secrets.cfClientId` | Client ID for cf auth provider | `nil` |
 | `secrets.cfClientSecret` | Client secret for cf auth provider | `nil` |
+| `secrets.conjurAccount` | Account for Conjur auth provider | `nil` |
+| `secrets.conjurAuthnLogin` | Host username for Conjur auth provider | `nil` |
+| `secrets.conjurAuthnApiKey` | API key for host used for Conjur auth provider. Either API key or token file can be used, but not both. | `nil` |
+| `secrets.conjurAuthnTokenFile` | Token file used for Conjur auth provider if running in Kubernetes or IAM. Either token file or API key can be used, but not both. | `nil` |
+| `secrets.conjurCertFile` | Token file used for Conjur auth provider if running in Kubernetes or IAM | `nil` |
 | `secrets.create` | Create the secret resource from the following values. *See [Secrets](#secrets)* | `true` |
 | `secrets.credhubCaCert` | Value of PEM-encoded CA cert file to use to verify the CredHub server SSL cert. | `nil` |
 | `secrets.credhubClientId` | Client ID for CredHub authorization. | `nil` |
@@ -131,6 +136,8 @@ The following table lists the configurable parameters of the Concourse chart and
 | `secrets.influxdbPassword` | Password used to authenticate with influxdb | `nil` |
 | `secrets.ldapCaCert` | CA Certificate for LDAP | `nil` |
 | `secrets.localUsers` | Create concourse local users. Default username and password are `test:test` *See [values.yaml](values.yaml)* |
+| `secrets.microsoftClientId` | Client ID for Microsoft authorization. | `nil ` |
+| `secrets.microsoftClientSecret` | Client secret for Microsoft authorization. | `nil` |
 | `secrets.oauthCaCert` | CA certificate for Generic OAuth | `nil` |
 | `secrets.oauthClientId` | Application client ID for Generic OAuth | `nil` |
 | `secrets.oauthClientSecret` | Application client secret for Generic OAuth | `nil` |

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -819,6 +819,14 @@ spec:
             - name: CONCOURSE_MAIN_TEAM_OIDC_USER
               value: {{ .Values.concourse.web.auth.mainTeam.oidc.user | quote }}
             {{- end }}
+            {{- if .Values.concourse.web.auth.mainTeam.microsoft.user }}
+            - name: CONCOURSE_MAIN_TEAM_MICROSOFT_USER
+              value: {{ .Values.concourse.web.auth.mainTeam.microsoft.user | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.auth.mainTeam.microsoft.group }}
+            - name: CONCOURSE_MAIN_TEAM_MICROSOFT_GROUP
+              value: {{ .Values.concourse.web.auth.mainTeam.microsoft.group | quote }}
+            {{- end }}
             {{- if .Values.concourse.web.auth.cf.enabled }}
             - name: CONCOURSE_CF_CLIENT_ID
               valueFrom:
@@ -1061,6 +1069,26 @@ spec:
               value: {{ .Values.concourse.web.auth.oidc.userNameKey | quote }}
             {{- end }}
             {{- end }}
+
+            {{- if .Values.concourse.web.auth.microsoft.enabled }}
+            - name: CONCOURSE_MICROSOFT_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.web.fullname" . }}
+                  key: microsoft-client-id
+            - name: CONCOURSE_MICROSOFT_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.web.fullname" . }}
+                  key: microsoft-client-secret
+            - name: CONCOURSE_MICROSOFT_TENANT
+              value: {{ .Values.concourse.web.auth.microsoft.tenant | quote }}
+            - name: CONCOURSE_MICROSOFT_GROUPS
+              value: {{ .Values.concourse.web.auth.microsoft.groups | quote }}
+            - name: CONCOURSE_MICROSOFT_ONLY_SECURITY_GROUPS
+              value: {{ .Values.concourse.web.auth.microsoft.onlySecurityGroups | quote }}
+            {{- end }}
+
             {{- if .Values.concourse.web.peerAddress }}
             - name: CONCOURSE_PEER_ADDRESS
               value: {{ .Values.concourse.web.peerAddress | quote }}

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -547,6 +547,43 @@ spec:
                   key: credhub-client-key
             {{- end }}
             {{- end }}
+
+            {{- if .Values.concourse.web.conjur.enabled }}
+            - name: CONCOURSE_CONJUR_APPLIANCE_URL
+              value: {{ .Values.concourse.web.conjur.applianceUrl | quote }}
+            - name: CONCOURSE_CONJUR_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.web.fullname" . }}
+                  key: conjur-account
+            - name: CONCOURSE_CONJUR_CERT_FILE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.web.fullname" . }}
+                  key: conjur-cert-file
+            - name: CONCOURSE_CONJUR_AUTHN_LOGIN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.web.fullname" . }}
+                  key: conjur-authn-login
+            - name: CONCOURSE_CONJUR_AUTHN_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.web.fullname" . }}
+                  key: conjur-authn-api-key
+            - name: CONCOURSE_CONJUR_AUTHN_TOKEN_FILE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.web.fullname" . }}
+                  key: conjur-authn-token-file
+            - name: CONCOURSE_CONJUR_PIPELINE_SECRET_TEMPLATE
+              value: {{ .Values.concourse.web.conjur.pipelineSecretTemplate | quote }}
+            - name: CONCOURSE_CONJUR_TEAM_SECRET_TEMPLATE
+              value: {{ .Values.concourse.web.conjur.teamSecretTemplate | quote }}
+            - name: CONCOURSE_CONJUR_SECRET_TEMPLATE
+              value: {{ .Values.concourse.web.conjur.secretTemplate | quote }}
+            {{- end }}
+
             {{- if .Values.concourse.web.noop }}
             - name: CONCOURSE_NOOP
               value: {{ .Values.concourse.web.noop | quote }}

--- a/templates/web-secrets.yaml
+++ b/templates/web-secrets.yaml
@@ -60,6 +60,10 @@ data:
   oidc-client-secret: {{ template "concourse.secret.required" dict "key" "oidcClientSecret" "is" "concourse.web.auth.oidc.enabled" "root" . }}
   oidc-ca-cert: {{ default "" .Values.secrets.oidcCaCert | b64enc | quote }}
   {{- end }}
+  {{- if .Values.concourse.web.auth.microsoft.enabled }}
+  microsoft-client-id: {{ template "concourse.secret.required" dict "key" "microsoftClientId" "is" "concourse.web.auth.microsoft.enabled" "root" . }}
+  microsoft-client-secret: {{ template "concourse.secret.required" dict "key" "microsoftClientSecret" "is" "concourse.web.auth.microsoft.enabled" "root" . }}
+  {{- end }}
   {{- if .Values.concourse.web.tls.enabled }}
   web-tls-cert: {{ template "concourse.secret.required" dict "key" "webTlsCert" "is" "concourse.web.tls.enabled" "root" . }}
   web-tls-key: {{ template "concourse.secret.required" dict "key" "webTlsKey" "is" "concourse.web.tls.enabled" "root" . }}

--- a/templates/web-secrets.yaml
+++ b/templates/web-secrets.yaml
@@ -83,6 +83,13 @@ data:
   {{- required (printf "value %s is not recognized as an option for concourse.web.credhub.authenticationMode" .Values.concourse.web.credhub.authenticationMode) "" }}
   {{- end }}
   {{- end }}
+  {{- if .Values.concourse.web.conjur.enabled }}
+  conjur-account: {{ template "concourse.secret.required" dict "key" "conjurAccount" "is" "concourse.web.auth.conjur.enabled" "root" . }}
+  conjur-authn-login: {{ template "concourse.secret.required" dict "key" "conjurAuthnLogin" "is" "concourse.web.auth.conjur.enabled" "root" . }}
+  conjur-authn-api-key: {{ default "" .Values.secrets.conjurAuthnApiKey | b64enc | quote }}
+  conjur-authn-token-file: {{ default "" .Values.secrets.conjurAuthnTokenFile | b64enc | quote }}
+  conjur-cert-file: {{ default "" .Values.secrets.conjurCertFile | b64enc | quote }}
+  {{- end }}
   {{- if .Values.concourse.web.awsSsm.enabled }}
   aws-ssm-access-key: {{ default "" .Values.secrets.awsSsmAccessKey | b64enc | quote }}
   aws-ssm-secret-key: {{ default "" .Values.secrets.awsSsmSecretKey | b64enc | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -496,6 +496,18 @@ concourse:
       ##
       authenticationMode: "secrets"
 
+    ## TODO link to docs: Configuration for using Conjur as a credential manager.
+    ##
+    conjur:
+      enabled: false
+
+      # URL of the Conjur instance.
+      applianceUrl:
+
+      # Optional overrides for pattern of storing different types of secrets.
+      pipelineSecretTemplate:
+      teamSecretTemplate:
+      secretTemplate:
 
     ## Don't actually do any automatic scheduling or checking.
     ##
@@ -2104,3 +2116,20 @@ secrets:
   ## SSL certificate used to verify the Syslog server for draining build logs.
   ##
   syslogCaCert:
+
+  ## Secrets for Conjur credentials manager.
+  #
+  # Org account.
+  conjurAccount:
+
+  # Host username. E.g host/concourse
+  conjurAuthnLogin:
+
+  # Api key related to the host.
+  conjurAuthnApiKey:
+
+  # Token file used if conjur instance is running in k8s or iam. E.g. /path/to/token_file
+  conjurAuthnTokenFile:
+
+  # Cert file used if conjur instance is using a self signed cert. E.g. /path/to/conjur.pem
+  conjurCertFile:

--- a/values.yaml
+++ b/values.yaml
@@ -820,6 +820,18 @@ concourse:
           ##
           group:
 
+        ## Authentication (Main Team) (Microsoft Login)
+        ##
+        microsoft:
+
+          ## List of whitelisted Microsoft users
+          ##
+          user:
+
+          ## List of whitelisted Microsoft groups
+          ##
+          group:
+
       ## Authentication (CloudFoundry)
       ##
       cf:
@@ -1035,6 +1047,19 @@ concourse:
         ## Concourse user name.
         ##
         userNameKey: username
+
+      ## Authentication (Microsoft)
+      microsoft:
+        enabled: false
+
+        # Microsoft Tenant limitation (common, consumers, organizations, tenant name or tenant uuid)
+        tenant:
+
+        # Allowed Active Directory Groups
+        groups:
+
+        # Only fetch security groups
+        onlySecurityGroups:
 
     tsa:
       ## Minimum level of logs to see. Possible values: debug, info, error.
@@ -2075,6 +2100,10 @@ secrets:
   oidcClientId:
   oidcClientSecret:
   oidcCaCert:
+
+  ## Secrets for Microsoft Auth.
+  microsoftClientId:
+  microsoftClientSecret:
 
   ## Secrets for using Hashcorp Vault as a credential manager.
   ##


### PR DESCRIPTION
# Existing Issue

Addresses https://github.com/concourse/concourse-chart/issues/34.

# Why do we need this PR?

Helm packaging and the Concourse binary's `web` configs have drifted since a few PRs got merged in. This reconciles some of that!

# Changes proposed in this pull request

* Add configs for Microsoft auth connector
* Add configs for Conjur credential manager
* ~Add config for Vault namespace~ looks like Jamie and Zoe did this in #33 

# Contributor Checklist
- [x] Variables are documented in the `README.md`

# Reviewer Checklist
- [ ] Code reviewed
- [ ] Topgun tests run