### PR TITLE
Revert "update the main team cf params"

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -674,17 +674,13 @@ spec:
             - name: CONCOURSE_MAIN_TEAM_LOCAL_USER
               value: {{ .Values.concourse.web.auth.mainTeam.localUser | quote }}
             {{- end }}
-            {{- if .Values.concourse.web.auth.mainTeam.cf.insecureOrg }}
-            - name: CONCOURSE_MAIN_TEAM_CF_INSECURE_ORG
-              value: {{ .Values.concourse.web.auth.mainTeam.cf.insecureOrg | quote }}
+            {{- if .Values.concourse.web.auth.mainTeam.cf.org }}
+            - name: CONCOURSE_MAIN_TEAM_CF_ORG
+              value: {{ .Values.concourse.web.auth.mainTeam.cf.org | quote }}
             {{- end }}
-            {{- if .Values.concourse.web.auth.mainTeam.cf.insecureSpace }}
-            - name: CONCOURSE_MAIN_TEAM_CF_INSECURE_SPACE
-              value: {{ .Values.concourse.web.auth.mainTeam.cf.insecureSpace | quote }}
-            {{- end }}
-            {{- if .Values.concourse.web.auth.mainTeam.cf.orgGuid }}
-            - name: CONCOURSE_MAIN_TEAM_CF_ORG_GUID
-              value: {{ .Values.concourse.web.auth.mainTeam.cf.orgGuid | quote }}
+            {{- if .Values.concourse.web.auth.mainTeam.cf.space }}
+            - name: CONCOURSE_MAIN_TEAM_CF_SPACE
+              value: {{ .Values.concourse.web.auth.mainTeam.cf.space | quote }}
             {{- end }}
             {{- if .Values.concourse.web.auth.mainTeam.cf.spaceGuid }}
             - name: CONCOURSE_MAIN_TEAM_CF_SPACE_GUID

--- a/values.yaml
+++ b/values.yaml
@@ -677,17 +677,13 @@ concourse:
 
           ## List of whitelisted CloudFoundry orgs
           ##
-          insecureOrg:
+          org:
 
           ## List of whitelisted CloudFoundry spaces
           ##
-          insecureSpace:
+          space:
 
-          ## List of whitelisted CloudFoundry org guids
-          ##
-          orgGuid:
-
-          ## List of whitelisted CloudFoundry space guids
+          ## (Deprecated) List of whitelisted CloudFoundry space guids
           ##
           spaceGuid:
 


### PR DESCRIPTION
Flags were changed back to their original values.

https://github.com/concourse/concourse/blob/c0858b3fba91c092a9eb0d38bc77279dc266afd5/skymarshal/skycmd/cf_flags.go#L70-L75