### PR TITLE
Made worker security context configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ The following table lists the configurable parameters of the Concourse chart and
 | `worker.replicas` | Number of Concourse Worker replicas | `2` |
 | `worker.resources.requests.cpu` | Minimum amount of cpu resources requested | `100m` |
 | `worker.resources.requests.memory` | Minimum amount of memory resources requested | `512Mi` |
+| `worker.securityContext.allowPrivilegeEscalation` | Allow privilege escalation (For kubelet v1.15+ set to `true` | `false` |
+| `worker.securityContext.privileged` | Set privileged security context (For kubelet v1.15+ set to `false` | `true` |
 | `worker.sidecarContainers` | Array of extra containers to run alongside the Concourse worker container | `nil` |
 | `worker.terminationGracePeriodSeconds` | Upper bound for graceful shutdown to allow the worker to drain its tasks | `60` |
 | `worker.tolerations` | Tolerations for the worker nodes | `[]` |

--- a/templates/worker-statefulset.yaml
+++ b/templates/worker-statefulset.yaml
@@ -56,7 +56,7 @@ spec:
           {{- end }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
           securityContext:
-            privileged: true
+          {{- toYaml .Values.worker.securityContext | nindent 12 }}
           command:
             - /bin/bash
           args:
@@ -280,7 +280,7 @@ spec:
 {{ toYaml .Values.worker.resources | indent 12 }}
 {{- end }}
           securityContext:
-            privileged: true
+          {{- toYaml .Values.worker.securityContext | nindent 12 }}
           volumeMounts:
             - name: concourse-keys
               mountPath: {{ .Values.worker.keySecretsPath | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -1625,6 +1625,15 @@ worker:
   ##
   replicas: 2
 
+  ## Set privileged security context
+  ## For kubelet v1.15+ change to:
+  ## securityContext:
+  ##   privileged: false
+  ##   allowPrivilegeEscalation: true
+  securityContext:
+    privileged: true
+    allowPrivilegeEscalation: false
+
   ## Array of extra containers to run alongside the Concourse worker
   ## container.
   ##

--- a/values.yaml
+++ b/values.yaml
@@ -1625,8 +1625,9 @@ worker:
   ##
   replicas: 2
 
-  ## Set privileged security context
+  ## Set security context
   ## For kubelet v1.15+ change to:
+  #
   ## securityContext:
   ##   privileged: false
   ##   allowPrivilegeEscalation: true


### PR DESCRIPTION
# Why do we need this PR?
Concourse workers fail to deploy on kubernetes with kubelet v1.15+ due to the removal of the flag `--allow-privileged`

The workaround is to change the pod security context from `privileged: true` to `allowPrivilegeEscalation: true`
See this github issue for more information: https://github.com/ubuntu/microk8s/issues/583

# Changes proposed in this pull request

* Worker pod security context is now injected from the values file 
* I have kept the same default behaviour

# Contributor Checklist
- [x] Variables are documented in the `README.md`


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
