### PR TITLE
Add examples for RBAC and mainTeam config

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -711,7 +711,14 @@ concourse:
       ##
       useCaCert: false
 
-    ## Customize RBAC role-action mapping.
+    ## Customize RBAC role-action mapping. Pass in as a multi-line YAML string
+    ## Ref: https://concourse-ci.org/user-roles.html#configuring-rbac
+    ## Example:
+    ## configRBAC: |
+    ##   owner:
+    ##   - SetTeam
+    ##   member:
+    ##   - CreateBuild
     ##
     configRBAC:
 
@@ -725,8 +732,18 @@ concourse:
       duration: 24h
 
       mainTeam:
-        ## Configuration file for specifying team params.
+
+        ## Configuration file for specifying the main teams params.
         ## Ref: https://concourse-ci.org/managing-teams.html#setting-roles
+        ## Example:
+        ## config: |
+        ##   roles:
+        ##   - name: owner
+        ##     local:
+        ##       users: ["admin"]
+        ##   - name: member
+        ##     local:
+        ##       users: ["test"]
         ##
         config:
 


### PR DESCRIPTION
# Existing Issue
Closes #46 

# Why do we need this PR?
We got user feedback that it was unclear how these values were meant to
be passed to the helm chart. Users were trying to pass in a YAML object instead of a multi-line YAML string.

This PR adds examples to the default values.yaml which should make this clearer for
users of the chart.

# Contributor Checklist
- [x] ~Variables are documented in the `README.md`~

# Reviewer Checklist
- [x] Code reviewed
- [x] ~Topgun tests run~
- [x] ~Back-port if needed~