### PR TITLE
Add serviceMonitor object to the chart

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 9.0.0
+version: 9.1.0
 appVersion: 5.8.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.nameOverride` | Override the Concourse Web components name | `nil` |
 | `web.nodeSelector` | Node selector for web nodes | `{}` |
 | `web.postgresqlSecretsPath` | Specify the mount directory of the web postgresql secrets | `/concourse-postgresql` |
+| `web.prometheus.enabled` | Enable the Prometheus metrics endpoint | `false` |
+| `web.prometheus.bindIp` | IP to listen on to expose Prometheus metrics | `0.0.0.0` |
+| `web.prometheus.bindPort` | Port to listen on to expose Prometheus metrics | `9391` |
+| `web.prometheus.ServiceMonitor.enabled` | Enable the creation of a serviceMonitor object for the Prometheus operator | `false` |
+| `web.prometheus.ServiceMonitor.interval` | The interval the Prometheus endpoint is scraped | `30s` |
+| `web.prometheus.ServiceMonitor.namespace` | The namespace where the serviceMonitor object has to be created | `nil` |
 | `web.readinessProbe.httpGet.path` | Path to access on the HTTP server when performing the healthcheck | `/api/v1/info` |
 | `web.readinessProbe.httpGet.port` | Name or number of the port to access on the container | `atc` |
 | `web.replicas` | Number of Concourse Web replicas | `1` |

--- a/templates/web-servicemonitor.yaml
+++ b/templates/web-servicemonitor.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.concourse.web.prometheus.serviceMonitor.enabled .Values.concourse.web.prometheus.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "concourse.web.fullname" . }}
+  {{- if .Values.concourse.web.prometheus.serviceMonitor.namespace }}
+  namespace: {{ .Values.concourse.web.prometheus.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "concourse.web.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  endpoints:
+  - interval: {{ .Values.concourse.web.prometheus.serviceMonitor.interval }}
+    port: prometheus
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "concourse.web.fullname" . }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -643,6 +643,13 @@ concourse:
       ##
       bindPort: 9391
 
+      ## If Prometheus operator is used, also create a servicemonitor object
+      serviceMonitor:
+        enabled: false
+        interval: "30s"
+        # Namespace the servicemonitor object should be in
+        namespace: 
+
     riemann:
       enabled: false
 


### PR DESCRIPTION
Signed-off-by: Yannick Kint <yannick.kint@gmail.com>

# Why do we need this PR?
Make it possible to use the prometheus-operator in combination with this chart.


# Changes proposed in this pull request

* Add ability to enable the creation of a serviceMonitor object for the prometheus-operator. The serviceMonitor will make sure the metrics are scraped by prometheus.

# Contributor Checklist
- [x] Variables are documented in the `README.md`


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
