### PR TITLE
make tracing flags configurable

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -155,6 +155,22 @@ spec:
             - name: CONCOURSE_AWS_SSM_REGION
               value: {{ .Values.concourse.web.awsSsm.region | quote }}
             {{- end }}
+            {{- if .Values.concourse.web.tracing.jaegerEndpoint }}
+            - name: CONCOURSE_TRACING_JAEGER_ENDPOINT
+              value: {{ .Values.concourse.web.tracing.jaegerEndpoint | quote }}
+            {{-end }}
+            {{- if .Values.concourse.web.tracing.jaegerTags }}
+            - name: CONCOURSE_TRACING_JAEGER_TAGS
+              value: {{ .Values.concourse.web.tracing.jaegerTags | quote }}
+            {{-end }}
+            {{- if .Values.concourse.web.tracing.jaegerService }}
+            - name: CONCOURSE_TRACING_JAEGER_SERVICE
+              value: {{ .Values.concourse.web.tracing.jaegerService | quote }}
+            {{-end }}
+            {{- if .Values.concourse.web.tracing.stackdriverProjectId }}
+            - name: CONCOURSE_TRACING_STACKDRIVER_PROJECTID
+              value: {{ .Values.concourse.web.tracing.stackdriverProjectId | quote }}
+            {{-end }}
             {{- if .Values.concourse.web.metrics.bufferSize }}
             - name: CONCOURSE_METRICS_BUFFER_SIZE
               value: {{ .Values.concourse.web.metrics.bufferSize | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -535,6 +535,31 @@ concourse:
       ##
       resource:
 
+    tracing:
+      ## Jaeger's HTTP-based Thrift collector endpoint.
+      #
+      ## Example: "http://jaeger:14268/api/traces"
+      ##
+      jaegerEndpoint:
+
+      ## Tags to include to components
+      ##
+      ## Example: "foo:bar,caz:zaz"
+      ##
+      jaegerTags:
+
+      ## Name of the service being traced
+      ##
+      ## Example: "web"
+      ##
+      jaegerService:
+
+      ## GCP's Project ID
+      ##
+      ## Example: "my-projectid"
+      ##
+      stackdriverProjectId:
+
     metrics:
       ## Host string to attach to emitted metrics.
       ##


### PR DESCRIPTION
### Why do we need this PR?

makes the changes from https://github.com/concourse/concourse/pull/5043 configurable

ps.: this is not yet available on "released" versions of concourse (e.g., it'll arrive on 6.0) - am I doing this right, @taylorsilva ?

### Changes proposed in this pull request

add `concourse.web.tracing.*` values to `values.yaml`, as well as the `web-deployment.yaml` template.

### Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- ~[ ] Variables are documented in the `README.md`~ the flags are concourse-specific

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed

---

thankss!
