### PR TITLE
web-deployment: fix conditional syntax

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -158,19 +158,19 @@ spec:
             {{- if .Values.concourse.web.tracing.jaegerEndpoint }}
             - name: CONCOURSE_TRACING_JAEGER_ENDPOINT
               value: {{ .Values.concourse.web.tracing.jaegerEndpoint | quote }}
-            {{-end }}
+            {{- end }}
             {{- if .Values.concourse.web.tracing.jaegerTags }}
             - name: CONCOURSE_TRACING_JAEGER_TAGS
               value: {{ .Values.concourse.web.tracing.jaegerTags | quote }}
-            {{-end }}
+            {{- end }}
             {{- if .Values.concourse.web.tracing.jaegerService }}
             - name: CONCOURSE_TRACING_JAEGER_SERVICE
               value: {{ .Values.concourse.web.tracing.jaegerService | quote }}
-            {{-end }}
+            {{- end }}
             {{- if .Values.concourse.web.tracing.stackdriverProjectId }}
             - name: CONCOURSE_TRACING_STACKDRIVER_PROJECTID
               value: {{ .Values.concourse.web.tracing.stackdriverProjectId | quote }}
-            {{-end }}
+            {{- end }}
             {{- if .Values.concourse.web.metrics.bufferSize }}
             - name: CONCOURSE_METRICS_BUFFER_SIZE
               value: {{ .Values.concourse.web.metrics.bufferSize | quote }}


### PR DESCRIPTION
when adding the tracing configuration, I mistakenly types `{{-end}}`
(instead of `{{- end }}`. shame on me.

tested with `concourse/concourse`'s `topgun/k8s` to make sure we
got it right.