### PR TITLE
Wrap config map in if-checks

### DIFF
--- a/templates/web-configmap.yaml
+++ b/templates/web-configmap.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.web.enabled -}}
+{{- if or .Values.concourse.web.auth.mainTeam.config .Values.concourse.web.configRBAC -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,5 +10,11 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
+  {{- if .Values.concourse.web.auth.mainTeam.config }}
   main-team.yml: {{ .Values.concourse.web.auth.mainTeam.config | quote }}
+  {{- end -}}
+  {{- if .Values.concourse.web.configRBAC }}
   config-rbac.yml: {{ .Values.concourse.web.configRBAC | quote }}
+  {{- end -}}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
# Existing Issue
Fixes #50 and #62

# Why do we need this PR?

We only want to create the config map if either of the two values have
been set. This also caused installs using the default values.yml to fail 
because we would try to create an invalid config map.

Tested all four ways of setting the config map:
- nothing set
- main team config
- rbac
- main team and rbac

All worked correctly. Here's the configmap for when both main team and rbac config are set:

```
$ kubectl describe configmaps bbb-web
Name:         bbb-web
Namespace:    default
Labels:       app=bbb-web
              chart=concourse-9.0.0
              heritage=Helm
              release=bbb
Annotations:  <none>

Data
====
config-rbac.yml:
----
owner:
  -SetTeam

main-team.yml:
----
roles:
- name: owner
  local:
    users: ["test"]
```

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] ~Variables are documented in the `README.md`~


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
