### PR TITLE
Fixed helm v3 chart validation issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 charts
-*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 charts
+*.swp

--- a/values.yaml
+++ b/values.yaml
@@ -752,7 +752,7 @@ concourse:
     ##   member:
     ##   - CreateBuild
     ##
-    configRBAC:
+    configRBAC: ""
 
     auth:
       ## Force sending secure flag on http cookies
@@ -777,7 +777,7 @@ concourse:
         ##     local:
         ##       users: ["test"]
         ##
-        config:
+        config: ""
 
         ## List of local Concourse users to be included as members of the `main` team.
         ## Make sure you have local users support enabled (`concourse.web.localAuth.enabled`) and


### PR DESCRIPTION
# Why do we need this PR?
Fixed the validation issues preventing helm v3 from installing the chart.

# Changes proposed in this pull request

*  Set default value for configRBAC to empty string
*  Set default value for mainTeam config to empty string

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
