### PR TITLE
Fixed helm v3 chart validation issues

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -713,7 +713,7 @@ concourse:
 
     ## Customize RBAC role-action mapping.
     ##
-    configRBAC:
+    configRBAC: ""
 
     auth:
       ## Force sending secure flag on http cookies
@@ -728,7 +728,7 @@ concourse:
         ## Configuration file for specifying team params.
         ## Ref: https://concourse-ci.org/managing-teams.html#setting-roles
         ##
-        config:
+        config: ""
 
         ## List of local Concourse users to be included as members of the `main` team.
         ## Make sure you have local users support enabled (`concourse.web.localAuth.enabled`) and


### PR DESCRIPTION
# Why do we need this PR?
Fixed the validation issues preventing helm v3 from installing the chart.

# Changes proposed in this pull request

*  Set default value for configRBAC to empty string
*  Set default value for mainTeam config to empty string

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed