### PR TITLE
[#4847] Set default rebalance-interval

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -1203,7 +1203,7 @@ concourse:
 
     ## Duration after which the registration should be swapped to another random SSH gateway.
     ##
-    rebalanceInterval:
+    rebalanceInterval: 4h
 
     ## Duration after which a worker should give up draining forwarded connections on shutdown.
     ##


### PR DESCRIPTION
- set default rebalance-interval for workers to reconnect to the TSA to 4h
- previously this value wasn't set