### PR TITLE
disable web tls certs when lets encrypt is enabled

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 9.1.0
+version: 9.1.1
 appVersion: 5.8.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -201,10 +201,12 @@ spec:
             {{- if .Values.concourse.web.tls.enabled }}
             - name: CONCOURSE_TLS_BIND_PORT
               value: {{ .Values.concourse.web.tls.bindPort | quote }}
+            {{- if not .Values.concourse.web.letsEncrypt.enabled }}
             - name: CONCOURSE_TLS_CERT
               value: "{{ .Values.web.tlsSecretsPath }}/client.cert"
             - name: CONCOURSE_TLS_KEY
               value: "{{ .Values.web.tlsSecretsPath }}/client.key"
+            {{- end }}
             {{- end }}
             {{- if .Values.concourse.web.tls.enabled }}
             - name: CONCOURSE_EXTERNAL_URL
@@ -1245,9 +1247,11 @@ spec:
               readOnly: true
             {{- end }}
             {{- if .Values.concourse.web.tls.enabled }}
+            {{- if not .Values.concourse.web.letsEncrypt.enabled }}
             - name: web-tls
               mountPath: {{ .Values.web.tlsSecretsPath | quote }}
               readOnly: true
+            {{- end }}
             {{- end }}
             {{- if .Values.concourse.web.vault.enabled }}
             - name: vault-keys
@@ -1313,6 +1317,7 @@ spec:
             {{- end }}
         {{- end }}
         {{- if .Values.concourse.web.tls.enabled }}
+        {{- if not .Values.concourse.web.letsEncrypt.enabled }}
         - name: web-tls
           secret:
             secretName: {{ template "concourse.web.fullname" . }}
@@ -1322,6 +1327,7 @@ spec:
                 path: client.cert
               - key: web-tls-key
                 path: client.key
+        {{- end }}
         {{- end }}
         {{- if .Values.concourse.web.vault.enabled }}
         - name: vault-keys

--- a/templates/web-secrets.yaml
+++ b/templates/web-secrets.yaml
@@ -65,8 +65,10 @@ data:
   microsoft-client-secret: {{ template "concourse.secret.required" dict "key" "microsoftClientSecret" "is" "concourse.web.auth.microsoft.enabled" "root" . }}
   {{- end }}
   {{- if .Values.concourse.web.tls.enabled }}
+  {{- if not .Values.concourse.web.letsEncrypt.enabled }}
   web-tls-cert: {{ template "concourse.secret.required" dict "key" "webTlsCert" "is" "concourse.web.tls.enabled" "root" . }}
   web-tls-key: {{ template "concourse.secret.required" dict "key" "webTlsKey" "is" "concourse.web.tls.enabled" "root" . }}
+  {{- end }}
   {{- end }}
   {{- if .Values.concourse.web.vault.enabled }}
   vault-ca-cert: {{ default "" .Values.secrets.vaultCaCert | b64enc | quote }}


### PR DESCRIPTION
# Why do we need this PR?
With the implementation of auto certs in concourse, it will panic when user enable lets encrypt and providing certs at the same time. 

# Changes proposed in this pull request
Disable web tls certs when lets encrypt is opt in.

# Reviewer Checklist
- [x] Code reviewed
- [x] Topgun tests run
- [x] Back-port if needed - concourse/concourse-chart#80
