### PR TITLE
5.5.x: LetsEncrypt takes precedence over supplied cert

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 8.2.8
+version: 8.2.9
 appVersion: 5.5.8
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -185,10 +185,12 @@ spec:
             {{- if .Values.concourse.web.tls.enabled }}
             - name: CONCOURSE_TLS_BIND_PORT
               value: {{ .Values.concourse.web.tls.bindPort | quote }}
+            {{- if not .Values.concourse.web.letsEncrypt.enabled }}
             - name: CONCOURSE_TLS_CERT
               value: "{{ .Values.web.tlsSecretsPath }}/client.cert"
             - name: CONCOURSE_TLS_KEY
               value: "{{ .Values.web.tlsSecretsPath }}/client.key"
+            {{- end }}
             {{- end }}
             {{- if .Values.concourse.web.tls.enabled }}
             - name: CONCOURSE_EXTERNAL_URL
@@ -1094,9 +1096,11 @@ spec:
               readOnly: true
             {{- end }}
             {{- if .Values.concourse.web.tls.enabled }}
+            {{- if not .Values.concourse.web.letsEncrypt.enabled }}
             - name: web-tls
               mountPath: {{ .Values.web.tlsSecretsPath | quote }}
               readOnly: true
+            {{- end }}
             {{- end }}
             {{- if .Values.concourse.web.vault.enabled }}
             - name: vault-keys
@@ -1152,6 +1156,7 @@ spec:
             {{- end }}
         {{- end }}
         {{- if .Values.concourse.web.tls.enabled }}
+        {{- if not .Values.concourse.web.letsEncrypt.enabled }}
         - name: web-tls
           secret:
             secretName: {{ template "concourse.web.fullname" . }}
@@ -1161,6 +1166,7 @@ spec:
                 path: client.cert
               - key: web-tls-key
                 path: client.key
+        {{- end }}
         {{- end }}
         {{- if .Values.concourse.web.vault.enabled }}
         - name: vault-keys

--- a/templates/web-secrets.yaml
+++ b/templates/web-secrets.yaml
@@ -61,8 +61,10 @@ data:
   oidc-ca-cert: {{ default "" .Values.secrets.oidcCaCert | b64enc | quote }}
   {{- end }}
   {{- if .Values.concourse.web.tls.enabled }}
+  {{- if not .Values.concourse.web.letsEncrypt.enabled }}
   web-tls-cert: {{ template "concourse.secret.required" dict "key" "webTlsCert" "is" "concourse.web.tls.enabled" "root" . }}
   web-tls-key: {{ template "concourse.secret.required" dict "key" "webTlsKey" "is" "concourse.web.tls.enabled" "root" . }}
+  {{- end }}
   {{- end }}
   {{- if .Values.concourse.web.vault.enabled }}
   vault-ca-cert: {{ default "" .Values.secrets.vaultCaCert | b64enc | quote }}


### PR DESCRIPTION
# Why do we need this PR?

Backports concourse/concourse-chart#79 to the 5.5.x series.

# Changes proposed in this pull request

* If Lets Encrypt is enabled, it takes precedence over any supplied cert.
* This avoids a panic/crash when both options are provided.

# Contributor Checklist
- [x] ~Variables are documented in the `README.md`~

# Reviewer Checklist
- [ ] Code reviewed
- [ ] Topgun tests run
- [x] ~Back-port if needed~