### PR TITLE
Allow deploying worker with Containerd backend

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 9.1.1
+version: 9.1.2
 appVersion: 5.8.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/templates/worker-statefulset.yaml
+++ b/templates/worker-statefulset.yaml
@@ -14,7 +14,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "concourse.worker.fullname" . }}
-      release: {{ .Release.Name }}  
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:
@@ -200,6 +200,10 @@ spec:
             {{- if .Values.concourse.worker.garden.useHoudini }}
             - name: CONCOURSE_GARDEN_USE_HOUDINI
               value: {{ .Values.concourse.worker.garden.useHoudini | quote }}
+            {{- end }}
+            {{- if .Values.concourse.worker.garden.useContainerd }}
+            - name: CONCOURSE_GARDEN_USE_CONTAINERD
+              value: {{ .Values.concourse.worker.garden.useContainerd | quote }}
             {{- end }}
             {{- if .Values.concourse.worker.garden.bin }}
             - name: CONCOURSE_GARDEN_BIN

--- a/values.yaml
+++ b/values.yaml
@@ -1342,6 +1342,10 @@ concourse:
       ##
       useHoudini:
 
+      ## Use the experimental Containerd Garden backend.
+      ##
+      useContainerd:
+
       ## How long to wait for requests to Garden to complete. 0 means no timeout.
       ##
       requestTimeout:


### PR DESCRIPTION
# Existing Issue
Related to https://github.com/concourse/concourse/pull/5297

# Why do we need this PR?
So concourse chart could be used to deploy worker with Containerd backend

# Reviewer Checklist
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
