### PR TITLE
[bugfix] kubeversion lookup when helm offline

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 10.0.0
+version: 10.0.1
 appVersion: 6.0.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -66,7 +66,7 @@ Creates the address of the TSA service.
 Return the appropriate apiVersion for deployment.
 */}}
 {{- define "concourse.deployment.apiVersion" -}}
-{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.Version -}}
 {{- print "extensions/v1beta1" -}}
 {{- else -}}
 {{- print "apps/v1" -}}
@@ -77,7 +77,7 @@ Return the appropriate apiVersion for deployment.
 Return the appropriate apiVersion for statefulset.
 */}}
 {{- define "concourse.statefulset.apiVersion" -}}
-{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.Version -}}
 {{- print "apps/v1beta2" -}}
 {{- else -}}
 {{- print "apps/v1" -}}
@@ -88,7 +88,7 @@ Return the appropriate apiVersion for statefulset.
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "concourse.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
 {{- print "extensions/v1beta1" -}}
 {{- else -}}
 {{- print "networking.k8s.io/v1beta1" -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -66,11 +66,13 @@ Creates the address of the TSA service.
 Determine version of Kubernetes cluster
 */}}
 {{- define "concourse.kubeVersion" -}}
-{{- printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor  -}}
+{{- print (.Capabilities.KubeVersion.GitVersion | replace "v" "") -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for deployment.
+Sometimes GitVersion will contain a `v` so we need
+to strip that out.
 */}}
 {{- define "concourse.deployment.apiVersion" -}}
 {{- $version := include "concourse.kubeVersion" . -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -63,10 +63,18 @@ Creates the address of the TSA service.
 {{- end -}}
 
 {{/*
+Determine version of Kubernetes cluster
+*/}}
+{{- define "concourse.kubeVersion" -}}
+{{- printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor  -}}
+{{- end -}}
+
+{{/*
 Return the appropriate apiVersion for deployment.
 */}}
 {{- define "concourse.deployment.apiVersion" -}}
-{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.Version -}}
+{{- $version := include "concourse.kubeVersion" . -}}
+{{- if semverCompare "<1.9-0" $version -}}
 {{- print "extensions/v1beta1" -}}
 {{- else -}}
 {{- print "apps/v1" -}}
@@ -77,7 +85,8 @@ Return the appropriate apiVersion for deployment.
 Return the appropriate apiVersion for statefulset.
 */}}
 {{- define "concourse.statefulset.apiVersion" -}}
-{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.Version -}}
+{{- $version := include "concourse.kubeVersion" . -}}
+{{- if semverCompare "<1.9-0" $version -}}
 {{- print "apps/v1beta2" -}}
 {{- else -}}
 {{- print "apps/v1" -}}
@@ -88,7 +97,8 @@ Return the appropriate apiVersion for statefulset.
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "concourse.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
+{{- $version := include "concourse.kubeVersion" . -}}
+{{- if semverCompare "<1.14-0" $version -}}
 {{- print "extensions/v1beta1" -}}
 {{- else -}}
 {{- print "networking.k8s.io/v1beta1" -}}


### PR DESCRIPTION
Signed-off-by: Paul Czarkowski <username.taken@gmail.com>

# Why do we need this PR?

When Helm is unable to talk to a kube cluster it picks a default
kube version to use for Capabilities.  This allows helm template
and similar commands to work.

However this chart keys off .Capabiltities.KubeVersion.GitVersion, the
which sometimes has a `v` prefix and thus the logic
above the semver tests and assumes its a really old cluster.

This results in deprecated kube apis being used which fails on
clusters newer than 1.16.


# Changes proposed in this pull request

This PR Updates the helpers to remove any `v` from the gitversion string that is returned.

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
