### PR TITLE
Allow extra initContainers for both web and worker pods.

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 10.0.0
+version: 10.0.1
 appVersion: 6.0.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.service.tsaNodePort` | Sets the nodePort for tsa when using `NodePort` | `nil` |
 | `web.service.type` | Concourse Web service type | `ClusterIP` |
 | `web.sidecarContainers` | Array of extra containers to run alongside the Concourse web container | `nil` |
+| `web.extraInitContainers` | Array of extra init containers to run before the Concourse web container | `nil` |
 | `web.strategy` | Strategy for updates to deployment. | `{}` |
 | `web.syslogSecretsPath` | Specify the mount directory of the web syslog secrets | `/concourse-syslog` |
 | `web.tlsSecretsPath` | Where in the container the web TLS secrets should be mounted | `/concourse-web-tls` |
@@ -242,6 +243,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `worker.resources.requests.cpu` | Minimum amount of cpu resources requested | `100m` |
 | `worker.resources.requests.memory` | Minimum amount of memory resources requested | `512Mi` |
 | `worker.sidecarContainers` | Array of extra containers to run alongside the Concourse worker container | `nil` |
+| `worker.extraInitContainers` | Array of extra init containers to run before the Concourse worker container | `nil` |
 | `worker.terminationGracePeriodSeconds` | Upper bound for graceful shutdown to allow the worker to drain its tasks | `60` |
 | `worker.tolerations` | Tolerations for the worker nodes | `[]` |
 | `worker.updateStrategy` | `OnDelete` or `RollingUpdate` (requires Kubernetes >= 1.7) | `RollingUpdate` |

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -45,6 +45,10 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if .Values.web.extraInitContainers }}
+      initContainers:
+      {{- toYaml .Values.web.extraInitContainers | nindent 8 }}
+      {{- end }}
       containers:
       {{- if .Values.web.sidecarContainers }}
       {{- toYaml .Values.web.sidecarContainers | nindent 8 }}

--- a/templates/worker-statefulset.yaml
+++ b/templates/worker-statefulset.yaml
@@ -48,6 +48,9 @@ spec:
       {{- end }}
       {{- if .Values.worker.cleanUpWorkDirOnStart }}
       initContainers:
+      {{- if .Values.worker.extraInitContainers }}
+      {{- toYaml .Values.worker.extraInitContainers | nindent 8 }}
+      {{- end }}
         - name: {{ template "concourse.worker.fullname" . }}-init-rm
           {{- if .Values.imageDigest }}
           image: "{{ .Values.image }}@{{ .Values.imageDigest }}"

--- a/values.yaml
+++ b/values.yaml
@@ -1686,7 +1686,7 @@ worker:
   ##
   sidecarContainers: []
 
-  ## Array of extra initContainers to run alongside the Concourse Web
+  ## Array of extra initContainers to run alongside the Concourse worker
   ## container.
   ##
   ## Example:

--- a/values.yaml
+++ b/values.yaml
@@ -1416,6 +1416,16 @@ web:
   ##
   sidecarContainers: []
 
+  ## Array of extra initContainers to run alongside the Concourse Web
+  ## container.
+  ##
+  ## Example:
+  ## - name: myapp-init-container
+  ##   image: busybox
+  ##   command: ['sh', '-c', 'echo Hello && sleep 3600']
+  ##
+  extraInitContainers: []
+
   ## Configures the liveness probe used to determine if the Web component is up.
   ## ps.: if you're upgrading Concourse from one version  to another, the probe will
   ## probably fail for some time before migrations are finished - in such situations,
@@ -1675,6 +1685,16 @@ worker:
   ##   command: ['sh', '-c', 'echo Hello && sleep 3600']
   ##
   sidecarContainers: []
+
+  ## Array of extra initContainers to run alongside the Concourse Web
+  ## container.
+  ##
+  ## Example:
+  ## - name: myapp-init-container
+  ##   image: busybox
+  ##   command: ['sh', '-c', 'echo Hello && sleep 3600']
+  ##
+  extraInitContainers: []
 
   ## Minimum number of workers available after an eviction
   ## Ref: https://kubernetes.io/docs/admin/disruptions/


### PR DESCRIPTION
# Existing Issue
N/A

# Why do we need this PR?
We are currently maintaining a fork of this chart to add 10 lines of yaml as an `initContainer` to the web pods, this change will make this no longer required. 

# Changes proposed in this pull request
> What are the changes included in this PR? Feel free to add as many lines as needed below.

* Adding optional `initContainers` to worker pods
* Adding optional `initContainers` to web pods

# Contributor Checklist
- [x] Variables are documented in the `README.md`

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
