### PR TITLE
Roll pods on config/secets changes

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 10.0.1
+version: 10.0.4
 appVersion: 6.0.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -25,8 +25,10 @@ spec:
         {{- with .Values.web.labels }}
 {{ toYaml . | trim | indent 8 }}
         {{- end }}
-      {{- if .Values.web.annotations }}
       annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/web-secrets.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/web-configmap.yaml") . | sha256sum }}
+      {{- if .Values.web.annotations }}
 {{ toYaml .Values.web.annotations | indent 8 }}
       {{- end }}
     spec:

--- a/templates/worker-statefulset.yaml
+++ b/templates/worker-statefulset.yaml
@@ -23,9 +23,10 @@ spec:
         {{- with .Values.worker.labels }}
 {{ toYaml . | trim | indent 8 }}
         {{- end }}
-      {{- if .Values.worker.annotations }}
       annotations:
-{{ toYaml .Values.worker.annotations | indent 8 }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/worker-secrets.yaml") . | sha256sum }}
+  {{- if .Values.worker.annotations }}
+  {{ toYaml .Values.worker.annotations | indent 8 }}
       {{- end }}
     spec:
     {{- if .Values.worker.nodeSelector }}


### PR DESCRIPTION
follow suggestion from helm docs
https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
since changes for public worker keys did not get applied until pod restart
was triggered manually

Co-authored-by: Hans Mündelein <hans@oss.volkswagen.com>
Signed-off-by: Hannes Hasselbring <hannes@oss.volkswagen.com>


# Existing Issue
none

# Why do we need this PR?
When changing a secret or configMap with `helm upgrade` the changes are not applied until manually restarting the pod.


# Changes proposed in this pull request
* Following the [helm tips and tricks](https://helm.sh/docs/howto/charts_tips_and_tricks/\#automatically-roll-deployments), a hash of the generated configMaps/secrets is added
as an annotation, which leads to an automated restart of affected pods.

# Contributor Checklist

# Reviewer Checklist
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
