### PR TITLE
web: allow to override command and args

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 10.0.7
+version: 10.0.8
 appVersion: 6.0.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.datadog.prefix` | Prefix for emitted metrics | `"concourse.ci"` |
 | `web.enabled` | Enable or disable the web component | `true` |
 | `web.env` | Configure additional environment variables for the web containers | `[]` |
+| `web.command` | Override the docker image command | `nil` |
+| `web.args` | Docker image command arguments | `["web"]` |
 | `web.ingress.annotations` | Concourse Web Ingress annotations | `{}` |
 | `web.ingress.enabled` | Enable Concourse Web Ingress | `false` |
 | `web.ingress.hosts` | Concourse Web Ingress Hostnames | `[]` |

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -62,8 +62,10 @@ spec:
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
           {{- end }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
-          args:
-            - web
+          {{- if .Values.web.command }}
+          command: {{ toJson .Values.web.command }}
+          {{- end }}
+          args: {{ toJson .Values.web.args }}
           env:
             {{- if .Values.concourse.web.clusterName }}
             - name: CONCOURSE_CLUSTER_NAME

--- a/values.yaml
+++ b/values.yaml
@@ -1418,6 +1418,14 @@ web:
   ##
   replicas: 1
 
+  ## Startup command for the web component.
+  ## Allows to override the docker image command
+  # command: ["dumb-init", "/usr/local/concourse/bin/concourse"]
+
+  ## Args of the startup command for the web component.
+  ##
+  args: ["web"]
+
   ## Array of extra containers to run alongside the Concourse Web
   ## container.
   ##


### PR DESCRIPTION
# Existing Issue

It is currently not possible to change the way concourse-web is started without building a new docker image with a custom entrypoint.

# Changes proposed in this pull request

Allow to override the docker image entrypoint by specifying a `command`.
Allow to change the default `args` of the `command`

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Variables are documented in the `README.md`

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [x] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed