### PR TITLE
add `--concurrent-request-limit`

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 10.2.2
+version: 10.2.3
 appVersion: 6.1.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -103,6 +103,10 @@ spec:
             - name: CONCOURSE_LIDAR_CHECKER_INTERVAL
               value: {{ .Values.concourse.web.lidarCheckerInterval | quote }}
             {{- end }}
+            {{- if .Values.concourse.web.concurrentRequestLimits }}
+            - name: CONCOURSE_CONCURRENT_REQUEST_LIMIT
+              value: {{ .Values.concourse.web.concurrentRequestLimits | quote }}
+            {{- end }}
             {{- if .Values.concourse.web.enableBuildAuditing }}
             - name: CONCOURSE_ENABLE_BUILD_AUDITING
               value: {{ .Values.concourse.web.enableBuildAuditing | quote }}

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -105,7 +105,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.concurrentRequestLimits }}
             - name: CONCOURSE_CONCURRENT_REQUEST_LIMIT
-              value: {{ .Values.concourse.web.concurrentRequestLimits | quote }}
+              value: "{{- $local := dict "first" true -}}{{- range $k, $v := .Values.concourse.web.concurrentRequestLimits -}}{{- if not $local.first -}},{{- end -}}{{- $k -}}:{{- $v -}}{{- $_ := set $local "first" false -}}{{- end -}}"
             {{- end }}
             {{- if .Values.concourse.web.enableBuildAuditing }}
             - name: CONCOURSE_ENABLE_BUILD_AUDITING

--- a/values.yaml
+++ b/values.yaml
@@ -102,6 +102,10 @@ concourse:
     ##
     lidarCheckerInterval:
 
+    ## Limit the number of concurrent requests to an API endpoint (Example: ListAllJobs:5)
+    ##
+    concurrentRequestLimits:
+
     ## Enable auditing for all api requests connected to builds.
     ##
     enableBuildAuditing: false

--- a/values.yaml
+++ b/values.yaml
@@ -102,7 +102,10 @@ concourse:
     ##
     lidarCheckerInterval:
 
-    ## Limit the number of concurrent requests to an API endpoint (Example: ListAllJobs:5)
+    ## Limit the number of concurrent requests to an API endpoint.
+    ##
+    ## Example:
+    ##   ListAllJobs: 5
     ##
     concurrentRequestLimits:
 


### PR DESCRIPTION
# Existing Issue

Contributes to concourse/concourse#5421.

# Changes proposed in this pull request

I decided to make the `values.yaml` entry be the plural "limits" becase we
will definitely be adding support for specifying multiple limits separated by
commas in the future, and I don't want to have to change the parameter name at
that point.

# Contributor Checklist
- [x] ~Variables are documented in the `README.md`~

# Reviewer Checklist
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed