### PR TITLE
Fix indention of annotations on workers.

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 10.0.5
+version: 10.0.6
 appVersion: 6.0.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/templates/worker-statefulset.yaml
+++ b/templates/worker-statefulset.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/worker-secrets.yaml") . | sha256sum }}
   {{- if .Values.worker.annotations }}
-  {{ toYaml .Values.worker.annotations | indent 8 }}
+{{ toYaml .Values.worker.annotations | indent 8 }}
       {{- end }}
     spec:
     {{- if .Values.worker.nodeSelector }}


### PR DESCRIPTION
# Why do we need this PR?

The indention of a toYaml function call seems to be indention dependent and insertion of annotations on workers recently got moved one indent in. ( see https://github.com/concourse/concourse-chart/commit/b1b0d0306bfb5061297b53ae1fcdaffe2b98a3a9 )
This leads to illegal kubernetes yaml being generated when you add annotations.

# Changes proposed in this pull request

* Remove indent of annotation insertion

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] ~~Variables are documented in the `README.md`~~


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
