### PR TITLE
add parameters to enable the creation of podsecuritypolicy

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 10.0.5
+version: 10.1.0
 appVersion: 6.0.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ The following table lists the configurable parameters of the Concourse chart and
 | `rbac.create` | Enables creation of RBAC resources | `true` |
 | `rbac.webServiceAccountName` | Name of the service account to use for web pods if `rbac.create` is `false` | `default` |
 | `rbac.workerServiceAccountName` | Name of the service account to use for workers if `rbac.create` is `false` | `default` |
-| `podSecurityPolicy.create` | Enables creation of podsecuritypolicy resources | `false` |
-| `podSecurityPolicy.allowedWorkerVolumes` | List of volumes allowed by the podsecuritypolicy for the worker pods | *See [values.yaml](values.yaml)* |
-| `podSecurityPolicy.allowedWebVolumes` | List of volumes allowed by the podsecuritypolicy for the web pods | *See [values.yaml](values.yaml)* |
+| `podSecurityPolicy.create` | Enables creation of podSecurityPolicy resources | `false` |
+| `podSecurityPolicy.allowedWorkerVolumes` | List of volumes allowed by the podSecurityPolicy for the worker pods | *See [values.yaml](values.yaml)* |
+| `podSecurityPolicy.allowedWebVolumes` | List of volumes allowed by the podSecurityPolicy for the web pods | *See [values.yaml](values.yaml)* |
 | `secrets.awsSecretsmanagerAccessKey` | AWS Access Key ID for Secrets Manager access | `nil` |
 | `secrets.awsSecretsmanagerSecretKey` | AWS Secret Access Key ID for Secrets Manager access | `nil` |
 | `secrets.awsSecretsmanagerSessionToken` | AWS Session Token for Secrets Manager access | `nil` |

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ The following table lists the configurable parameters of the Concourse chart and
 | `rbac.create` | Enables creation of RBAC resources | `true` |
 | `rbac.webServiceAccountName` | Name of the service account to use for web pods if `rbac.create` is `false` | `default` |
 | `rbac.workerServiceAccountName` | Name of the service account to use for workers if `rbac.create` is `false` | `default` |
+| `podSecurityPolicy.create` | Enables creation of podsecuritypolicy resources | `false` |
+| `podSecurityPolicy.allowedWorkerVolumes` | List of volumes allowed by the podsecuritypolicy for the worker pods | *See [values.yaml](values.yaml)* |
+| `podSecurityPolicy.allowedWebVolumes` | List of volumes allowed by the podsecuritypolicy for the web pods | *See [values.yaml](values.yaml)* |
 | `secrets.awsSecretsmanagerAccessKey` | AWS Access Key ID for Secrets Manager access | `nil` |
 | `secrets.awsSecretsmanagerSecretKey` | AWS Secret Access Key ID for Secrets Manager access | `nil` |
 | `secrets.awsSecretsmanagerSessionToken` | AWS Session Token for Secrets Manager access | `nil` |

--- a/templates/web-podsecuritypolicy.yaml
+++ b/templates/web-podsecuritypolicy.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.web.enabled -}}
+{{- if .Values.podSecurityPolicy.create -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "concourse.web.fullname" . }}
+  labels:
+    app: {{ template "concourse.web.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  volumes:
+{{ toYaml .Values.podSecurityPolicy.allowedWebVolumes | indent 4 }}
+  runAsUser:
+    rule: 'RunAsAny'    
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: true
+{{- end -}}
+{{- end }}

--- a/templates/web-role.yaml
+++ b/templates/web-role.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.web.enabled -}}
 {{- if .Values.rbac.create -}}
-{{- if .Values.concourse.web.kubernetes.enabled -}}
+{{- if .Values.concourse.web.kubernetes.enabled }}
+---
 apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
 kind: ClusterRole
 metadata:
@@ -14,6 +15,24 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get"]
-{{- end -}}
+{{- end }}
+{{- if .Values.podSecurityPolicy.create }}
+---
+apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
+kind: ClusterRole
+metadata:
+  name: {{ template "concourse.web.fullname" . }}-psp
+  labels:
+    app: {{ template "concourse.web.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "concourse.web.fullname" . }}
+{{- end }}
 {{- end -}}
 {{- end -}}

--- a/templates/web-rolebinding.yaml
+++ b/templates/web-rolebinding.yaml
@@ -22,6 +22,26 @@ subjects:
   name: {{ template "concourse.web.fullname" $ }}
   namespace: {{ $.Release.Namespace }}
 {{- end }}
-{{- end -}}
+{{- end }}
+{{- if .Values.podSecurityPolicy.create }}
+---
+apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
+kind: RoleBinding
+metadata:
+  name: {{ template "concourse.web.fullname" . }}-psp
+  labels:
+    app: {{ template "concourse.web.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "concourse.web.fullname" . }}-psp
+subjects:
+- kind: ServiceAccount
+  name: {{ template "concourse.web.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end -}}
 {{- end -}}

--- a/templates/worker-podsecuritypolicy.yaml
+++ b/templates/worker-podsecuritypolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.worker.enabled -}}
 {{- if .Values.podSecurityPolicy.create -}}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "concourse.worker.fullname" . }}

--- a/templates/worker-podsecuritypolicy.yaml
+++ b/templates/worker-podsecuritypolicy.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.worker.enabled -}}
+{{- if .Values.podSecurityPolicy.create -}}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "concourse.worker.fullname" . }}
+  labels:
+    app: {{ template "concourse.worker.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - 'CAP_FOWNER'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  volumes:
+{{ toYaml .Values.podSecurityPolicy.allowedWorkerVolumes | indent 4 }}
+  runAsUser:
+    rule: 'RunAsAny'
+  runAsGroup:
+    rule: 'RunAsAny'    
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false
+{{- end -}}
+{{- end }}

--- a/templates/worker-role.yaml
+++ b/templates/worker-role.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.worker.enabled -}}
 {{- if .Values.rbac.create -}}
+{{- if .Values.podSecurityPolicy.create -}}
 apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
 kind: Role
 metadata:
@@ -15,8 +16,9 @@ rules:
   resources:
   - podsecuritypolicies
   resourceNames:
-  - privileged
+  - {{ template "concourse.worker.fullname" . }}
   verbs:
   - use
+{{- end -}}
 {{- end -}}
 {{- end }}

--- a/templates/worker-rolebinding.yaml
+++ b/templates/worker-rolebinding.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.worker.enabled -}}
 {{- if .Values.rbac.create -}}
+{{- if .Values.podSecurityPolicy.create -}}
 apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
 kind: RoleBinding
 metadata:
@@ -16,5 +17,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "concourse.worker.fullname" . }}
+{{- end -}}
 {{- end -}}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -1972,15 +1972,18 @@ rbac:
   ##
   workerServiceAccountName: default
 
-## For managing podSecurityPolicies. To make sure rbac objects are also created for the use of the podsecuritypolicy objects, 
+## For managing podSecurityPolicies. To make sure rbac objects are also created
+## for the use of the podsecuritypolicy objects, 
 ## set rbac.create to 'true' (this is the default value)
 ##
 podSecurityPolicy:
-  ## Create podSecurityPolicy objects for concourse. Set this to false if objects are not needed, or if they are managed outside helm.
+  ## Create podSecurityPolicy objects for concourse. Set this to false if 
+  ## objects are not needed, or if they are managed outside helm.
   ##
   create: false
 
-  ## By default use the recommended minimum set of volumes in kubernetes. Possible to overwrite if other types are used.
+  ## By default use the recommended minimum set of volumes in kubernetes.
+  ## Possible to overwrite if other types are used.
   ##
   allowedWorkerVolumes:
   - 'secret'
@@ -1990,7 +1993,8 @@ podSecurityPolicy:
   - 'emptyDir'
   - 'projected'
   
-  ## By default use the recommended minimum set of volumes in kubernetes. Possible to overwrite if other types are used.
+  ## By default use the recommended minimum set of volumes in kubernetes. 
+  ## Possible to overwrite if other types are used.
   ##
   allowedWebVolumes:
   - 'secret'

--- a/values.yaml
+++ b/values.yaml
@@ -1972,6 +1972,34 @@ rbac:
   ##
   workerServiceAccountName: default
 
+## For managing podSecurityPolicies. To make sure rbac objects are also created for the use of the podsecuritypolicy objects, 
+## set rbac.create to 'true' (this is the default value)
+##
+podSecurityPolicy:
+  ## Create podSecurityPolicy objects for concourse. Set this to false if objects are not needed, or if they are managed outside helm.
+  ##
+  create: false
+
+  ## By default use the recommended minimum set of volumes in kubernetes. Possible to overwrite if other types are used.
+  ##
+  allowedWorkerVolumes:
+  - 'secret'
+  - 'persistentVolumeClaim'
+  - 'configMap'
+  - 'downwardAPI'
+  - 'emptyDir'
+  - 'projected'
+  
+  ## By default use the recommended minimum set of volumes in kubernetes. Possible to overwrite if other types are used.
+  ##
+  allowedWebVolumes:
+  - 'secret'
+  - 'persistentVolumeClaim'
+  - 'configMap'
+  - 'downwardAPI'
+  - 'emptyDir'
+  - 'projected'
+
 ## For managing secrets using Helm
 ##
 secrets:


### PR DESCRIPTION
add parameters to enable the creation of podsecuritypolicy

Signed-off-by: Yannick Kint <yannick.kint@gmail.com>


# Why do we need this PR?
Concourse pods need some privileges at the moment (e.g. worker pods need to run as root, in a privileged container), in clusters with a default podsecuritypolicy that restricts this, a custom psp object is needed for concourse.


# Changes proposed in this pull request

* Add option in the values.yaml to enable the creation of psp objects
* When rbac.create is also enabled, make sure correct rbac objects are created so pods can use the psp objects

# Contributor Checklist
- [x] Variables are documented in the `README.md`


# Reviewer Checklist
- [ ] Code reviewed
- [x] Topgun tests run
- [ ] Back-port if needed
