### PR TITLE
The authorizedKeys values is not used at all.

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -1196,10 +1196,6 @@ concourse:
       ##
       hostKey:
 
-      ## Path to file containing keys to authorize, in SSH authorized_keys format (one public key per line).
-      ##
-      authorizedKeys:
-
       ## ATC API endpoints to which workers will be registered.
       ##
       atcUrl:


### PR DESCRIPTION
The values used to set authorizedKeys fall under `web` and `secerts`.
Search for `keys` in the values.yaml or look in the web-deployment.yaml
file and search for:

- CONCOURSE_TSA_AUTHORIZED_KEYS
- CONCOURSE_TSA_TEAM_AUTHORIZED_KEYS

You can then see which keys in values.yaml are used to populate the TSA
authorizedKeys.

# Existing Issue

Fixes #16

# Contributor Checklist

- [x] Variables are documented in the `README.md`

This variable was never actually documented.


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
