### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,3 +650,14 @@ The minimum IAM policy you need to use Secrets Manager with Concourse is:
   ]
 }
 ```
+
+## Developing
+
+- When adding a new Concourse flag, don't assign a `default` value in the `values.yml` that mirrors a default set by the Concourse binary. Instead, you may add a comment specifying the default, such as
+```
+      ## pipeline-specific template for SSM parameters, defaults to: /concourse/{{.Team}}/{{.Pipeline}}/{{.Secret}}
+      ##
+      pipelineSecretTemplate: /concourse/{{.Team}}/{{.Pipeline}}/{{.Secret}}
+
+``` 
+  This prevents the possiblity of drift if the Concourse binary default value changes.


### PR DESCRIPTION
Add `Developing` section with comment about not defining default values in the values.yml if they are specified in the Concourse binary.

# Why do we need this PR?
We want to introduce a convention of not specifying default values in values.yml` for flags that have defaults baked into the Concourse binary. 
Currently, this can result in having 2 sources of truth and introducing issues where the default value might be updated in the binary but be overridden by the chart unintentionally. 

By adding a default as a comment, it serves as an example. 

In the longer term,  it would be desirable for `values.yml` to be autogenerated so it serves as documentation but is derived from the binary (single source of truth).

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
