### PR TITLE
Servicemonitor metric relabeling

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 11.1.0
+version: 11.1.1
 appVersion: 6.2.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.prometheus.ServiceMonitor.enabled` | Enable the creation of a serviceMonitor object for the Prometheus operator | `false` |
 | `web.prometheus.ServiceMonitor.interval` | The interval the Prometheus endpoint is scraped | `30s` |
 | `web.prometheus.ServiceMonitor.namespace` | The namespace where the serviceMonitor object has to be created | `nil` |
+| `web.prometheus.ServiceMonitor.metricRelabelings` | Relabel metrics as defined [here](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs) | `nil` |
 | `web.readinessProbe.httpGet.path` | Path to access on the HTTP server when performing the healthcheck | `/api/v1/info` |
 | `web.readinessProbe.httpGet.port` | Name or number of the port to access on the container | `atc` |
 | `web.replicas` | Number of Concourse Web replicas | `1` |

--- a/templates/web-servicemonitor.yaml
+++ b/templates/web-servicemonitor.yaml
@@ -25,5 +25,4 @@ spec:
   selector:
     matchLabels:
       app: {{ template "concourse.web.fullname" . }}
-
 {{- end }}

--- a/templates/web-servicemonitor.yaml
+++ b/templates/web-servicemonitor.yaml
@@ -15,10 +15,15 @@ spec:
   endpoints:
   - interval: {{ .Values.concourse.web.prometheus.serviceMonitor.interval }}
     port: prometheus
+  {{- if .Values.concourse.web.prometheus.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{ toYaml .Values.concourse.web.prometheus.serviceMonitor.metricRelabelings | nindent 6 }}
+  {{- end }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
       app: {{ template "concourse.web.fullname" . }}
+
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -724,7 +724,15 @@ concourse:
         interval: "30s"
         # Namespace the servicemonitor object should be in
         namespace:
-        # Relabel Metrics - https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+
+        ## Relabel Metrics
+        ## https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+        ## Example:
+        ## metricRelabelings:
+        ##   - regex: 'instance'
+        #      action: labeldrop
+        #    - regex: 'pod'
+        #      action: labeldrop
         metricRelabelings:
 
     ## The value to set for X-Frame-Options. If omitted, the header is not set.

--- a/values.yaml
+++ b/values.yaml
@@ -727,12 +727,12 @@ concourse:
 
         ## Relabel Metrics
         ## https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
-        ## Example:
+        ## Example that consolidates duplicate metrics when web is running in HA:
         ## metricRelabelings:
         ##   - regex: 'instance'
-        #      action: labeldrop
-        #    - regex: 'pod'
-        #      action: labeldrop
+        ##     action: labeldrop
+        ##   - regex: 'pod'
+        ##     action: labeldrop
         metricRelabelings:
 
     ## The value to set for X-Frame-Options. If omitted, the header is not set.

--- a/values.yaml
+++ b/values.yaml
@@ -724,6 +724,8 @@ concourse:
         interval: "30s"
         # Namespace the servicemonitor object should be in
         namespace:
+        # Relabel Metrics - https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+        metricRelabelings:
 
     ## The value to set for X-Frame-Options. If omitted, the header is not set.
     ##


### PR DESCRIPTION
# Why do we need this PR?
This PR allows custom metric relabeling rules to be applied to the web-servicemonitor resource. This allows the user to consolidate duplicate metrics generated when running the web service in HA. I've left an example on how to do this in the values.yaml comments

# Changes proposed in this pull request
* Add variable `web.prometheus.ServiceMonitor.metricRelabelings`

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Variables are documented in the `README.md`

# Reviewer Checklist
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
