### PR TITLE
ServiceMonitor: add additional labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.prometheus.ServiceMonitor.enabled` | Enable the creation of a serviceMonitor object for the Prometheus operator | `false` |
 | `web.prometheus.ServiceMonitor.interval` | The interval the Prometheus endpoint is scraped | `30s` |
 | `web.prometheus.ServiceMonitor.namespace` | The namespace where the serviceMonitor object has to be created | `nil` |
+| `web.prometheus.ServiceMonitor.labels` | Additional lables for the serviceMonitor object | `nil` |
 | `web.prometheus.ServiceMonitor.metricRelabelings` | Relabel metrics as defined [here](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs) | `nil` |
 | `web.readinessProbe.httpGet.path` | Path to access on the HTTP server when performing the healthcheck | `/api/v1/info` |
 | `web.readinessProbe.httpGet.port` | Name or number of the port to access on the container | `atc` |

--- a/templates/web-servicemonitor.yaml
+++ b/templates/web-servicemonitor.yaml
@@ -11,6 +11,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    {{- with .Values.concourse.web.prometheus.serviceMonitor.labels }}
+{{ toYaml . | trim | indent 4 }}
+    {{- end }}    
 spec:
   endpoints:
   - interval: {{ .Values.concourse.web.prometheus.serviceMonitor.interval }}

--- a/values.yaml
+++ b/values.yaml
@@ -713,6 +713,16 @@ concourse:
         # Namespace the servicemonitor object should be in
         namespace:
 
+        ## Additional Labels to be added to the servicemonitor.
+        ##
+        ##
+        ## Example:
+        ##   key1: "value1"
+        ##   key2: "value2"
+        ##
+        ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+        labels: {}
+
         ## Relabel Metrics
         ## https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
         ## Example that consolidates duplicate metrics when web is running in HA:


### PR DESCRIPTION
This change allows to set additional labels for serviceMonitors.

# Why do we need this PR?
As the prometheus-operator allows to discover serviceMonitors by label, the ability to set additional labels in the values.yaml helps with this strategy.  


# Changes proposed in this pull request
* Append labels to the serviceMonitor object if defined 



# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Variables are documented in the `README.md`


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
