### PR TITLE
Don't link to deprecated tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ It is highly recommended to use Persistent Volumes for Concourse Workers; otherw
 
 ### Ingress TLS
 
-If your cluster allows automatic creation/retrieval of TLS certificates (e.g. [kube-lego](https://github.com/jetstack/kube-lego)), please refer to the documentation for that mechanism.
+If your cluster allows automatic creation/retrieval of TLS certificates (e.g. [cert-manager](https://github.com/jetstack/cert-manager/)), please refer to the documentation for that mechanism.
 
 To manually configure TLS, first create/retrieve a key & certificate pair for the address(es) you wish to protect. Then create a TLS secret in the namespace:
 


### PR DESCRIPTION
kube-lego has been deprecated in favour of cert-manager, update the README to reflect that