### PR TITLE
Generate secrets in a Job

### DIFF
--- a/templates/secret-generation.yaml
+++ b/templates/secret-generation.yaml
@@ -1,0 +1,116 @@
+{{- if .Values.worker.enabled  }}
+{{- if .Values.secrets.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    description: |
+      A Role that allows the secret generator below to create secrets for Concourse web and worker nodes.
+  name: secrets-generator
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - get
+  - create
+  - update
+  - delete
+  - patch
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: secrets-generator
+  namespace: {{ .Release.Namespace }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+  name: secrets-generator
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: secrets-generator
+subjects:
+- kind: ServiceAccount
+  name: secrets-generator
+  namespace: {{ .Release.Namespace }}
+
+---
+# This Job will patch the web and worker secrets in order to add 
+# key and ssh keys for 
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: secrets-generator-{{ .Release.Revision }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  template:
+    spec:
+      serviceAccountName: secrets-generator
+      restartPolicy: OnFailure
+      initContainers:
+      - name: generator
+        image: concourse/concourse
+        imagePullPolicy: Always
+        command:
+        - /bin/bash
+        - -c
+        - |
+          /usr/local/concourse/bin/concourse generate-key -t rsa -f ./secrets/session-signing-key
+          /usr/local/concourse/bin/concourse generate-key -t ssh -f ./secrets/host-key
+          /usr/local/concourse/bin/concourse generate-key -t ssh -f ./secrets/worker-key
+
+        volumeMounts:
+          - name: secrets
+            mountPath: /secrets
+      containers:
+      - name: secret-creator 
+        image: bitnami/kubectl
+        imagePullPolicy: Always
+        env:
+          - name: WORKER_SECRET_NAME
+            value: {{ template "concourse.worker.fullname" . }}
+          - name: WEB_SECRET_NAME
+            value: {{ template "concourse.web.fullname" . }}
+          - name: SECRET_NAMESPACE
+            value: {{ .Release.Namespace }}
+        command:
+        - /bin/bash
+        - -c
+        - |
+          HOST_KEY_PUB=$(awk '{printf "%s\\n", $0}' secrets/host-key.pub)
+          WORKER_KEY=$(awk '{printf "%s\\n", $0}' secrets/worker-key)
+          kubectl patch secret -n ${SECRET_NAMESPACE} ${WORKER_SECRET_NAME} -p "{\"stringData\":{\"host-key-pub\":\"${HOST_KEY_PUB}\"}}"
+          kubectl patch secret -n ${SECRET_NAMESPACE} ${WORKER_SECRET_NAME} -p "{\"stringData\":{\"worker-key\":\"${WORKER_KEY}\"}}"
+
+          SESSION_SIGNING_KEY=$(awk '{printf "%s\\n", $0}' secrets/session-signing-key)
+          WORKER_KEY_PUB=$(awk '{printf "%s\\n", $0}' secrets/worker-key.pub)
+          HOST_KEY=$(awk '{printf "%s\\n", $0}' secrets/host-key)
+          kubectl patch secret -n ${SECRET_NAMESPACE} ${WEB_SECRET_NAME} -p "{\"stringData\":{\"host-key\":\"${HOST_KEY}\"}}"
+          kubectl patch secret -n ${SECRET_NAMESPACE} ${WEB_SECRET_NAME} -p "{\"stringData\":{\"session-signing-key\":\"${SESSION_SIGNING_KEY}\"}}"
+          kubectl patch secret -n ${SECRET_NAMESPACE} ${WEB_SECRET_NAME} -p "{\"stringData\":{\"worker-key-pub\":\"${WORKER_KEY_PUB}\"}}"
+
+        volumeMounts:
+          - name: secrets
+            mountPath: /secrets
+      volumes:
+        - name: secrets
+          emptyDir: {}
+{{- end }}
+{{- end }}
+
+{{- if .Values.web.enabled  }}
+{{- if .Values.secrets.create }}
+
+{{- end }}
+{{- end }}

--- a/templates/web-secrets.yaml
+++ b/templates/web-secrets.yaml
@@ -11,9 +11,6 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
-  host-key: {{ .Values.secrets.hostKey | b64enc | quote }}
-  session-signing-key: {{ .Values.secrets.sessionSigningKey | b64enc | quote }}
-  worker-key-pub: {{ .Values.secrets.workerKeyPub | b64enc | quote }}
   {{- if .Values.concourse.web.clientConfig.enabled }}
   client-id: {{ template "concourse.secret.required" dict "key" "clientId" "is" "concourse.web.clientConfig.enabled" "root" . }}
   client-secret: {{ template "concourse.secret.required" dict "key" "clientSecret" "is" "concourse.web.clientConfig.enabled" "root" . }}

--- a/templates/worker-secrets.yaml
+++ b/templates/worker-secrets.yaml
@@ -10,8 +10,6 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque
-data:
-  host-key-pub: {{ .Values.secrets.hostKeyPub | b64enc | quote }}
-  worker-key: {{ .Values.secrets.workerKey | b64enc | quote }}
+data: # Will be filled in later by a Job
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -2217,105 +2217,21 @@ secrets:
   ## Concourse Host Keys.
   ## Ref: https://concourse-ci.org/install.html#generating-keys
   ##
-  hostKey: |-
-    -----BEGIN RSA PRIVATE KEY-----
-    MIIEogIBAAKCAQEA2AUPXxuiDC/qrBWjIdT5fvNcMlMEYpR3X4SLQIgLC1ULDsCO
-    fleKZ+Wi4RzwbkUKiKmJm5GeyNVVCDdfvdD1Sd1+5faqmp2/OQBzLS7o8NY/btMw
-    8h9lx4KVJaJJ1EM1EiyGY41Nx591KP14pBfr0/NdOIrDu2JvF6e7CHEbrzkN57kb
-    BVQkaIMaS01Rw/5Oe68GFalli2ii8L8dNWVVzquBh5PwVWimvTgwv3TYG2TH8L1V
-    V7n+/zRRpkjMl2+PUouGqD+Bp+4wF+hp4AW5v24CqjtLJEMv4IEJv2FRfrOauBIZ
-    XjAS1SSg9VaTOS3iwxaYrv8uG1XfMFHICvkEPQIDAQABAoIBAG87W8jrX6vK2Jm3
-    ooJ/OeFmymiXWsCwFi+2/kVCR/2T0tfLyxO/W+NX2WD1F9CP+HaaZeMXPp3HS7up
-    V8FT4ZohVYBwXTS0WYyucKApcYThrVQRpzhldnEfClGQmVeVK7Sp/KEyV4Sc1SVA
-    L2i/cI142N2Ohm7spquVkLcuFsVINzZ0fXCv25dTqbkEgjTJzNdBzyFXvc4z0Mt9
-    gW14M7mz+YKYOfsCxIEm438fC9b16C96yIFBdN+/jaP8pmb2RoIE2D0F8bj5K1hR
-    YyGFKMOU4e6cYq59iWfubKuu2WNJEBk/5aO7x7Xu2S0k8wIYlwxFuu4LfR2Kvizu
-    +mFVf3kCgYEA9e0+40tJGpOPM8hAB3DwXjYc8lCuyYf3z30T3RqVNCUVSWnlaj/s
-    3ENi6+Ng3u+Zs8cR2CFou+jAClTyWLuSnI9yACD0eyW9n4bzYMUbgdC6vneLjpzx
-    wWR9Xv5RmZVly7xWuqcgEeEf8RNcYI3oXby0laF3EObvuAx/4ETIkFcCgYEA4N42
-    w1UEWGopWBIIXYHkEPHQuF0SxR2CZyh9ExTeSxFphyibkcHRjDW+t91ZLnSm5k1N
-    TOdYuc0ApBV3U+TexeFvDI94L/Oze6Ht5MatRQz8kRwMFGJL3TrpbgTmWdfG05Ad
-    oiScJzwY16oJXnKusxik7V+gCCNNE0/2UuMnY4sCgYAEf82pvOPef5qcGOrK+A79
-    ukG3UTCRcVJgUmp9nhHivVbxW+WdlwPPV9BEfol0KrAGMPsrmBjhbzWsOregVfYt
-    tRYh2HiAlEUu2Po06AZDzrzL5UYBWu+1WRBOH5sAk1IkcxKnIY2dph++elszTQVW
-    SbCIGEckYQU7ucbRJJECywKBgBb4vHFx8vKxTa3wkagzx7+vZFohL/SxEgxFx5k2
-    bYsPqU8kZ9gZC7YeG3CfDShAxHgMd5QeoiLA/YrFop4QaG2gnP6UfXuwkqpTnYDc
-    hwDh1b9hNR6z9/oOtaAGoh2VfHtKYqyYvtcHPaZyeWiLoKstHlQdi7SpHouVhJ1t
-    FS4HAoGAGy+56+zvdROjJy9A2Mn/4BvWrsu4RSQILBJ6Hb4TpF46p2fn0rwqyhOj
-    Occs+xkdEsI9w5phXzIEeOq2LqvWHDPxtdLpxOrrmx4AftAWdM8S1+OqTpzHihK1
-    y1ZOrWfvON+XjWFFAEej/CpQZkNUkTzjTtSC0dnfAveZlasQHdI=
-    -----END RSA PRIVATE KEY-----
+  hostKey:
 
-  hostKeyPub: |-
-    ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYBQ9fG6IML+qsFaMh1Pl+81wyUwRilHdfhItAiAsLVQsOwI5+V4pn5aLhHPBuRQqIqYmbkZ7I1VUIN1+90PVJ3X7l9qqanb85AHMtLujw1j9u0zDyH2XHgpUloknUQzUSLIZjjU3Hn3Uo/XikF+vT8104isO7Ym8Xp7sIcRuvOQ3nuRsFVCRogxpLTVHD/k57rwYVqWWLaKLwvx01ZVXOq4GHk/BVaKa9ODC/dNgbZMfwvVVXuf7/NFGmSMyXb49Si4aoP4Gn7jAX6GngBbm/bgKqO0skQy/ggQm/YVF+s5q4EhleMBLVJKD1VpM5LeLDFpiu/y4bVd8wUcgK+QQ9 Concourse
+  hostKeyPub:
 
   ## Concourse Session Signing Keys.
   ## Ref: https://concourse-ci.org/concourse-generate-key.html
   ##
-  sessionSigningKey: |-
-    -----BEGIN RSA PRIVATE KEY-----
-    MIIEowIBAAKCAQEAwLql/rUIaI+PX7Tl3FWcTee4sQf8/daakALXx955tPwkhqlY
-    e4T2V84p/ylFvNWpM4vfcMYKfMY0JLKgAgBvJhCytSkDBhTBoWmN6yE0AB11P9En
-    lIZRBWNYqaC2cSge2ZD8qOSnwfFhnQAW8+7pE+ElJAVh7dtdF3A478H50lIigq8I
-    zMWp2EGJpFC7/Uu36oIL/03MNGCmrH1jvtTuJiAMQUZYyL1ReBkvvHOzw9i4HXPy
-    SMVtcllm4NBs2aVPtwhr2kwSkLt8t1bPdRn6OIyEAw5WktzAKaiZnkTvj6g3xzdp
-    zKcrdlBr9aznlNvoSinBUfvtwyFmvFN1HHbA9wIDAQABAoIBAE7G/DrUfI9gvtX7
-    90jMpYsigFe8UCjho2PiBZlo0o6r0bJJXiV+/8J8PqZRlHPPUc4EClzqVjcSPRYS
-    /VxUGRqSELoD/Xxq14rGvn+xnrO9VsOzFl6bWFq/dOpBCtHN+G4t2VifvgKES8YE
-    11z19sdta+UBXjn/RFnkQSGfRCI3QqTaYvjxevt0uWlyPmqkFPQQw8bvHIXzoB+B
-    rzeiMa++nMvbX5pAH9XA0BvhyuH3fHidTUwiVBpkMcpLWtjP0A0JTsecDdbinDDq
-    un2EIo8zMWRwKQN/JnUxsi8AUEigBTCUqeDgREXtW62uvFkSpcVMXwmVityLYIVy
-    qnVLUCECgYEA6IwXkP1qnSfcNeoVI/ypDuz1/kdqcjSPhLYe+jdiLLoFkMW9AlDm
-    lzwNaWlTFD9ygo+NjJCo63/A8HCm55sajws5hZ6r20vdZcKFMk9h0qF5oVA7lkQ2
-    gvG2WaznuU7KkqhfP+pXhiLgZKoJkst/+g7r6uHpredwDY6hxeBK4vsCgYEA1CqH
-    8ywC5qUo/36kQg/TU2adN/YEHdJAAbU23EVrGQSVmnXW08H2NLFk0tsxrwoNnbgp
-    PIk2J7BimbJvbND17ibr4GAklDTsR8aJkDl+0JgNCAK9N07qVt1s7FXzhg95jUL9
-    EQW55z60GAJpecqNwA4Jsa8P852N0355Obp92TUCgYBkOBvf7JcJ66fHxH4f6D+j
-    oxPQ5k5Fsck4VJS9GSlCRVkor09ptBvsiYDuMOoRC9b51YwXTDDAbWplNOd5YSrt
-    AtVjdKJz/BoKRO7KY9Owxs54au+DLxqfDDSeKRokjoRW+CE0lnXp5RX3zCAcF3+r
-    8MpTi9D9lYSBEzs84BDmCQKBgQCMcH6/K3HcJJVn0fd+tyUGftUw9sswxjySJNbk
-    pZrH263/qWMDls+Xf5kire9MU1ZCAWZiaN0NFoed/2wcVpGEDAV0548u/30r4bKr
-    YjOcdhmiJNYFJ1qdF0MDib2CDvpB1IbZXrX46RujDO2urbJ435HxKNVhR/had8xc
-    tyKYxQKBgCVDhN0MhnlUQJVZfX42APmF4gQg0r3sfL/NGXjEjMIKKFe5a88eZVHr
-    L8x1+dp0q7czC8a/l1DUuiwDKl8OEpxLsGCq/J/wAfrSMPifu6EUlbUwlJOPdgha
-    +p/KFAelHXJ2w/8yackAcarh35VP7ixhuvxswHNdgvfsBTFcjn30
-    -----END RSA PRIVATE KEY-----
+  sessionSigningKey:
 
   ## Concourse Worker Keys.
   ## Ref: https://concourse-ci.org/concourse-generate-key.html
   ##
-  workerKey: |-
-    -----BEGIN RSA PRIVATE KEY-----
-    MIIEpAIBAAKCAQEAuPehUmBXAQCoA7TLAQCYhf+vzcZVyj+VGXnMhLHnWLk7dRjo
-    CU8GgNamdS5h7G3ywxOvKA3YjOLr8XyOMLS4c+e8N7tIzlMWdiXhe0lcBH9Z1ai5
-    +Bof3/BlDUBksiKdc1A+QcfX6tDwMkOO5re1H4vOK3H/Cype58wCB03HYNgb05ED
-    fW1Bj2qvz29VtmyjwEMuDs100iMqwCfPUx9oxXmmX8sUBRmw/Y1Rx/8pdKIjKw3m
-    kWIHHBOSCPimO1qC47Aa8v/UH9hERCykyuFHiBiKlnIvZWm9bYvhsRTz4gt5KzRY
-    6OI0oVeHlLOHDSK48Da8VWij15lOqO2Nx6WssQIDAQABAoIBADET22UNFOi6MNpS
-    5S5N5ypezlnOD0NLnZcV3zMyNQ0wkNsgEakuo64Zxi7/cJIYFjq2hVoeWl//cdUw
-    VFYODYcLbMBo3AeKukH9CRf6PgUfeUmcrENtQxnbIiTi+hTd5GMNXod7rAmtCJ59
-    mHQVOGS3ZqvWYnKm+mmMktk3RPinynX/A4y3WHPacuAS58HM09Ck43WcHMxbGpsL
-    /gZpICyFYZ2DviM+AHyWGcmw7LJrpC0QHo6+BAFMs4xlUecNgVIFUpfOoAcfsdtG
-    K9j4AbuZ47iFisbay+1pyg/7O5eRTdGVQRtc7PBMOjea5jGsfmlDmdn1ZS50ykun
-    ANfoQ5UCgYEA9Ak73PRy9nLlRkt4OBCF/4fwThUCMedsnWaVjQBMJYim4FB2ivF5
-    cKdWt3y/RZI85KKYu0EXhLEoSIEAfz057R8t3QdVK4tZx6B47UFjBjCYeVMtwHDQ
-    prxQiOPHIHCplBNFuGzA5VXL9gQLRD+ek0uOy2GJJ0Wu1xyeouI+SW8CgYEAwgkO
-    TOtOogqmcAALjWgeeQiZetflSKbJlpQNhmCPAMm0SFI8eF4SpRXLzd41VC2mLIwT
-    L3tjc7/8ocXoElFM4L0fo9Lx/SHFH4JEn5FT0PXPmvsF2JRhsXJFLJSihxF/91Xs
-    2aBcQILPFzLcrI6OFUakNwGTU/CIxpkzRvQrG98CgYEAzNVnUuo4CNadzagRK3Xr
-    E3Yl5VRK+FpY17FAfA6w25xc/dFr/un61e0Po4no/ltmEz7LVfmn5O/ScTEemq5o
-    jbjrBShfe+JGpIH0nqiQlqR5hvSjZXEMIbfVHWGbRYZrQGgA0HEwZA7k2QXB8zI3
-    R0lXfSzMM5OQ0uwp12xxfa8CgYBHILq1R6zTicPpWprhg0FobNaWSX4rW7iaEjvC
-    /rJtP4Nu33Z7SUDcc1j6ZnJ2ISXBPrfpt/mE/OPHCZ1A2bysxadLjpBWkoKIQmCV
-    fdiTyQgJb+t8sSf+vDzPUs0hZjDaogzo2ff3TfxMLMDoIHnFItgfsdwn8QyygIZj
-    hC4pUQKBgQDqsxnkI6yXFE5gshnW7H8zqKNlzKd/dZEL6e+lRz4R3UY/KcEkRAfq
-    Yi3cwo9fE3U3kSmpl5MQwUjWm/BZ7JyueoY/4ndwaFPgc34IKsgJ0wau9pZiQAB1
-    DxpOSF+BR71Jx3sxvIdCODNTtm645j5yrZVnJAuMPofo5XFmunDoJA==
-    -----END RSA PRIVATE KEY-----
+  workerKey:
 
-  workerKeyPub: |-
-    ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC496FSYFcBAKgDtMsBAJiF/6/NxlXKP5UZecyEsedYuTt1GOgJTwaA1qZ1LmHsbfLDE68oDdiM4uvxfI4wtLhz57w3u0jOUxZ2JeF7SVwEf1nVqLn4Gh/f8GUNQGSyIp1zUD5Bx9fq0PAyQ47mt7Ufi84rcf8LKl7nzAIHTcdg2BvTkQN9bUGPaq/Pb1W2bKPAQy4OzXTSIyrAJ89TH2jFeaZfyxQFGbD9jVHH/yl0oiMrDeaRYgccE5II+KY7WoLjsBry/9Qf2ERELKTK4UeIGIqWci9lab1ti+GxFPPiC3krNFjo4jShV4eUs4cNIrjwNrxVaKPXmU6o7Y3Hpayx Concourse
-
+  workerKeyPub:
 
   ## Secrets for web interface login
   ##


### PR DESCRIPTION
because one could accidentally use the hardcoded defaults which would result
in publicly available SSH keys used in production.

Signed-off-by: Dimitris Karakasilis <dkarakasilis@suse.com>

# Existing Issue

Fixes #49 

# Why do we need this PR?

# Changes proposed in this pull request

* Remove hardcoded secrets from values.yaml
* Generate SSH keys (and a signing key) in a Job. The Job will fail until the Secrets are created and will patch as soon as they appear in order to add the SSH keys in them.

# Contributor Checklist
- [ ] Variables are documented in the `README.md`


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
