### PR TITLE
Bedrock 3977/conradc/fqdn concourse

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 11.2.1
+version: 11.2.2
 appVersion: 6.3.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -28,6 +28,8 @@ spec:
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/web-secrets.yaml") . | sha256sum }}
         checksum/config: {{ include (print $.Template.BasePath "/web-configmap.yaml") . | sha256sum }}
+        consul.hashicorp.com/connect-inject: "true"
+        consul.hashicorp.com/connect-service: {{ template "concourse.web.fullname" . }}
       {{- if .Values.web.annotations }}
 {{ toYaml .Values.web.annotations | indent 8 }}
       {{- end }}


### PR DESCRIPTION
Adds consul injector to web deployment for use with Ambassador.