### PR TITLE
add support for new containerd flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 charts
 .idea
+*.iml
 # Swap
 .*.swp
 [._]*.s[a-v][a-z]

--- a/README.md
+++ b/README.md
@@ -265,6 +265,15 @@ The following table lists the configurable parameters of the Concourse chart and
 | `worker.terminationGracePeriodSeconds` | Upper bound for graceful shutdown to allow the worker to drain its tasks | `60` |
 | `worker.tolerations` | Tolerations for the worker nodes | `[]` |
 | `worker.updateStrategy` | `OnDelete` or `RollingUpdate` (requires Kubernetes >= 1.7) | `RollingUpdate` |
+| `worker.runtime.type` | Runtime to use with the worker | `nil` |
+| `worker.containerd.bin` | Path to a containerd executable | `nil` |
+| `worker.containerd.config` | Path to a config file to use for the Containerd daemon | `nil` |
+| `worker.containerd.dnsProxyEnable` | Enable a proxy DNS server for Garden | `nil` |
+| `worker.containerd.dnsServers` | List of DNS server IP address to use instead of automatically determined servers | `nil` |
+| `worker.containerd.restrictedNetworks` | List of Network ranges to which traffic from containers will be restricted | `nil` |
+| `worker.containerd.maxContainers` | Max container capacity where 0 means no limit | `nil` |
+| `worker.containerd.networkPool` | Network range to use for dynamically allocated container subnets | `nil` |
+| `worker.containerd.requestTimeout` | Time to wait for requests to Containerd to complete | `nil` |
 
 For configurable Concourse parameters, refer to [`values.yaml`](values.yaml)' `concourse` section. All parameters under this section are strictly mapped from the `concourse` binary commands.
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -222,9 +222,9 @@ Return concourse environment variables for worker configuration
 - name: CONCOURSE_EXTERNAL_GARDEN_URL
   value: {{ .Values.concourse.worker.externalGardenUrl | quote }}
 {{- end }}
-{{- if .Values.concourse.worker.runtime.type }}
-- name: CONCOURSE_RUNTIME_TYPE
-  value: {{ .Values.concourse.worker.runtime.type | quote }}
+{{- if .Values.concourse.worker.runtime }}
+- name: CONCOURSE_RUNTIME
+  value: {{ .Values.concourse.worker.runtime | quote }}
 {{- end }}
 {{- if .Values.concourse.worker.garden.bin }}
 - name: CONCOURSE_GARDEN_BIN

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -242,14 +242,6 @@ Return concourse environment variables for worker configuration
 - name: CONCOURSE_GARDEN_REQUEST_TIMEOUT
   value: {{ .Values.concourse.worker.garden.requestTimeout | quote }}
 {{- end }}
-{{- if .Values.concourse.worker.garden.dnsServer }}
-- name: CONCOURSE_GARDEN_DNS_SERVER
-  value: {{ .Values.concourse.worker.garden.dnsServer | quote }}
-{{- end }}
-{{- if .Values.concourse.worker.containerNetworkPool }}
-- name: CONCOURSE_CONTAINER_NETWORK_POOL
-  value: {{ .Values.concourse.worker.containerNetworkPool | quote }}
-{{- end }}
 {{- if .Values.concourse.worker.baggageclaim.logLevel }}
 - name: CONCOURSE_BAGGAGECLAIM_LOG_LEVEL
   value: {{ .Values.concourse.worker.baggageclaim.logLevel | quote }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -242,6 +242,42 @@ Return concourse environment variables for worker configuration
 - name: CONCOURSE_GARDEN_REQUEST_TIMEOUT
   value: {{ .Values.concourse.worker.garden.requestTimeout | quote }}
 {{- end }}
+{{- if .Values.concourse.worker.containerd.bin }}
+- name: CONCOURSE_CONTAINERD_BIN
+  value: {{ .Values.concourse.worker.containerd.bin | quote }}
+{{- end }}
+{{- if .Values.concourse.worker.containerd.config }}
+- name: CONCOURSE_CONTAINERD_CONFIG
+  value: {{ .Values.concourse.worker.containerd.config | quote }}
+{{- end }}
+{{- if .Values.concourse.worker.containerd.dnsProxyEnable }}
+- name: CONCOURSE_CONTAINERD_DNS_PROXY_ENABLE
+  value: {{ .Values.concourse.worker.containerd.dnsProxyEnable | quote }}
+{{- end }}
+{{- if .Values.concourse.worker.containerd.dnsServers }}
+{{- range .Values.concourse.worker.containerd.dnsServers }}
+- name: CONCOURSE_CONTAINERD_DNS_SERVER
+  value: {{ . | title | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.concourse.worker.containerd.restrictedNetworks }}
+{{- range .Values.concourse.worker.containerd.restrictedNetworks }}
+- name: CONCOURSE_CONTAINERD_RESTRICTED_NETWORK
+  value: {{ . | title | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.concourse.worker.containerd.maxContainers }}
+- name: CONCOURSE_CONTAINERD_MAX_CONTAINERS
+  value: {{ .Values.concourse.worker.containerd.maxContainers }}
+{{- end }}
+{{- if .Values.concourse.worker.containerd.networkPool }}
+- name: CONCOURSE_CONTAINERD_NETWORK_POOL
+  value: {{ .Values.concourse.worker.containerd.networkPool | quote }}
+{{- end }}
+{{- if .Values.concourse.worker.containerd.requestTimeout }}
+- name: CONCOURSE_CONTAINERD_REQUEST_TIMEOUT
+  value: {{ .Values.concourse.worker.containerd.requestTimeout | quote }}
+{{- end }}
 {{- if .Values.concourse.worker.baggageclaim.logLevel }}
 - name: CONCOURSE_BAGGAGECLAIM_LOG_LEVEL
   value: {{ .Values.concourse.worker.baggageclaim.logLevel | quote }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -222,17 +222,9 @@ Return concourse environment variables for worker configuration
 - name: CONCOURSE_EXTERNAL_GARDEN_URL
   value: {{ .Values.concourse.worker.externalGardenUrl | quote }}
 {{- end }}
-{{- if .Values.concourse.worker.garden.useContainerd }}
-- name: CONCOURSE_GARDEN_USE_CONTAINERD
-  value: {{ .Values.concourse.worker.garden.useContainerd | quote }}
-{{- end }}
-{{- if .Values.concourse.worker.garden.useHoudini }}
-- name: CONCOURSE_GARDEN_USE_HOUDINI
-  value: {{ .Values.concourse.worker.garden.useHoudini | quote }}
-{{- end }}
-{{- if .Values.concourse.worker.garden.useContainerd }}
-- name: CONCOURSE_GARDEN_USE_CONTAINERD
-  value: {{ .Values.concourse.worker.garden.useContainerd | quote }}
+{{- if .Values.concourse.worker.runtime.type }}
+- name: CONCOURSE_RUNTIME_TYPE
+  value: {{ .Values.concourse.worker.runtime.type | quote }}
 {{- end }}
 {{- if .Values.concourse.worker.garden.bin }}
 - name: CONCOURSE_GARDEN_BIN

--- a/values.yaml
+++ b/values.yaml
@@ -1379,7 +1379,6 @@ concourse:
     runtime:
       ## Runtime to use with the worker. Possible values: guardian, containerd, houdini.
       ## Please note that Houdini is insecure and doesn't run 'tasks' in containers.
-      ## Defaults to "guardian" if unset.
       type:
 
     tsa:
@@ -1400,11 +1399,6 @@ concourse:
       ## File containing the private key to use when authenticating to the TSA.
       ##
       workerPrivateKey:
-
-    ## API endpoint of an externally managed Garden server to use instead of
-    ## running the embedded Garden server.
-    ##
-    externalGardenUrl:
 
     # The following refers to configuration for the Guardian runtime. For historical reasons
     # it is referred to as "garden" which is the server wrapping Guardian and the interface
@@ -1433,6 +1427,47 @@ concourse:
       ## How long to wait for requests to Garden to complete. 0 means no timeout.
       ##
       requestTimeout:
+
+    containerd:
+
+      ## Path to a containerd executable (non-absolute names get resolved from $PATH)."`
+      bin:
+
+      ## Path to a config file to use for the Containerd daemon.
+      config:
+
+      ## Enable a proxy DNS server for Garden
+      dnsProxyEnable:
+
+      ## List of DNS server IP addresses to use instead of automatically determined servers.
+      ## Example:
+      ## dnsServers:
+      ##   - 1.1.1.1
+      ##   - 2.2.2.2
+      dnsServers: []
+
+      ## List of network ranges to which traffic from containers will be restricted.
+      ## Example:
+      ## restrictedNetworks:
+      ##   - 1.1.1.1
+      ##   - 2.2.2.2
+      restrictedNetworks: []
+
+      ## Max container capacity. 0 means no limit.
+      maxContainers:
+
+      ## Network range to use for dynamically allocated container subnets, defaults to "10.80.0.0/16"
+      ##
+      networkPool:
+
+      ## Time to wait for requests to Containerd to complete. 0 means no timeout.
+      requestTimeout:
+
+
+    ## API endpoint of an externally managed Garden server to use instead of
+    ## running the embedded Garden server.
+    ##
+    externalGardenUrl:
 
     baggageclaim:
       ## Minimum level of logs to see. Possible values: debug, info, error

--- a/values.yaml
+++ b/values.yaml
@@ -1376,10 +1376,9 @@ concourse:
     ##
     volumeSweeperMaxInFlight: 5
 
+    ## Runtime to use with the worker. Possible values: guardian, containerd, houdini.
+    ## Please note that Houdini is insecure and doesn't run 'tasks' in containers.
     runtime:
-      ## Runtime to use with the worker. Possible values: guardian, containerd, houdini.
-      ## Please note that Houdini is insecure and doesn't run 'tasks' in containers.
-      type:
 
     tsa:
 

--- a/values.yaml
+++ b/values.yaml
@@ -1376,10 +1376,6 @@ concourse:
     ##
     volumeSweeperMaxInFlight: 5
 
-    ## Network pool to use for garden containers
-    ##
-    containerNetworkPool:
-
     runtime:
       ## Runtime to use with the worker. Possible values: guardian, containerd, houdini.
       ## Please note that Houdini is insecure and doesn't run 'tasks' in containers.
@@ -1410,12 +1406,12 @@ concourse:
     ##
     externalGardenUrl:
 
+    # The following refers to configuration for the Guardian runtime. For historical reasons
+    # it is referred to as "garden" which is the server wrapping Guardian and the interface
+    # that Guardian implements.
     garden:
-      ## Path to the executable to run the garden backend ('gdn' or
-      ## 'containerd').
-      ##
-      ## If not specified, the right binary will be search in $PATH.
-      ##
+      ## Path to a guardian executable (non-absolute names get resolved from $PATH).
+      ## This defaults to the gdn binary bundled with Concourse.
       bin:
 
       ## Path to a config file to use for Garden in INI format.
@@ -1433,10 +1429,6 @@ concourse:
       ## Enable a proxy DNS server for Garden
       ##
       dnsProxyEnable:
-
-      ## Custom DNS server to use for garden containers
-      ##
-      dnsServer:
 
       ## How long to wait for requests to Garden to complete. 0 means no timeout.
       ##

--- a/values.yaml
+++ b/values.yaml
@@ -1380,6 +1380,12 @@ concourse:
     ##
     containerNetworkPool:
 
+    runtime:
+      ## Runtime to use with the worker. Possible values: guardian, containerd, houdini.
+      ## Please note that Houdini is insecure and doesn't run 'tasks' in containers.
+      ## Defaults to "guardian" if unset.
+      type:
+
     tsa:
 
       ## TSA host(s) to forward the worker through.
@@ -1431,14 +1437,6 @@ concourse:
       ## Custom DNS server to use for garden containers
       ##
       dnsServer:
-
-      ## Use the insecure Houdini Garden backend.
-      ##
-      useHoudini:
-
-      ## Use the experimental containerd garden backend.
-      ##
-      useContainerd:
 
       ## How long to wait for requests to Garden to complete. 0 means no timeout.
       ##


### PR DESCRIPTION
# Existing Issue
Part of the PR concourse/concourse#5911, which addresses issue concourse/concourse#5407.

# Changes proposed in this pull request
* replace useContainerd and useHoudining with runtime.type
* remove redundant garden env vars
* add support for finalized containerd flags 

To test this I tried the following values in the `values.yml`

![Screen Shot 2020-07-29 at 8 25 01 AM](https://user-images.githubusercontent.com/5854091/88800646-7bb49600-d176-11ea-9114-8d4b767181dc.png)

![Screen Shot 2020-07-29 at 8 24 42 AM](https://user-images.githubusercontent.com/5854091/88800668-83743a80-d176-11ea-8b80-42e9563a3689.png)

I then ran `helm template` and got the following output:

![Screen Shot 2020-07-29 at 8 24 27 AM](https://user-images.githubusercontent.com/5854091/88800703-91c25680-d176-11ea-8395-f527860fe90a.png)


# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Variables are documented in the `README.md`


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed