### PR TITLE
Ensure statefulset workers have a unique id

### DIFF
--- a/templates/worker-statefulset.yaml
+++ b/templates/worker-statefulset.yaml
@@ -86,8 +86,15 @@ spec:
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
           {{- end }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+          command:
+            - /bin/bash
           args:
-            - worker
+            - -cex
+            - |-
+              export CONCOURSE_ID="{{ .Values.concourse.worker.workDir }}/CONCOURSE_ID"
+              [[ -f "$CONCOURSE_ID" ]] || echo $(shuf -i 1-100000 -n 1) > "$CONCOURSE_ID"
+              export CONCOURSE_NAME=$(hostname)-$(cat "$CONCOURSE_ID")
+              exec dumb-init /usr/local/bin/entrypoint.sh worker
 {{- if .Values.worker.livenessProbe }}
           livenessProbe:
 {{ toYaml .Values.worker.livenessProbe | indent 12 }}


### PR DESCRIPTION
When a worker shuts down, its marked as "retired", which removes its entry
from the concourse database. Unfortunately that doesn't always happen, and
when a newly started worker with a wiped disk joins with the same name, volume
errors occur as concourse expects "concourse-worker-0" to be the same machine.

This replicates the internal mechanism concourse uses to chose its worker name, but
augments it with a random identifier thats stored on the disk. This means the worker
will remain the same during container restarts, but not pod reschedules which run the
init container to clear the disk.

# Existing Issue
https://github.com/concourse/concourse-chart/issues/15

# Reviewer Checklist
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
