### PR TITLE
web: add CONCOURSE_TSA_GARDEN_REQUEST_TIMEOUT

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -1238,6 +1238,10 @@ spec:
                   name: {{ template "concourse.web.fullname" . }}
                   key: tsa-client-secret
             {{- end }}
+            {{- if .Values.concourse.web.tsa.gardenRequestTimeout }}
+            - name: CONCOURSE_TSA_GARDEN_REQUEST_TIMEOUT
+              value: {{ .Values.concourse.web.tsa.gardenRequestTimeout | quote }}
+            {{- end }}
             {{- if .Values.concourse.web.letsEncrypt.enabled }}
             - name: CONCOURSE_ENABLE_LETS_ENCRYPT
               value: {{ .Values.concourse.web.letsEncrypt.enabled | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -1257,6 +1257,10 @@ concourse:
       ##
       heartbeatInterval: 30s
 
+      ## How long to wait for requests to Garden to complete. 0 means no timeout.
+      ##
+      gardenRequestTimeout:
+
     letsEncrypt:
       ## Automatically configure TLS certificates via Let's Encrypt/ACME.
       ##


### PR DESCRIPTION
`CONCOURSE_TSA_GARDEN_REQUEST_TIMEOUT` was added in https://github.com/concourse/concourse/pull/5845. This PR allows that value to be configured in the chart.
