### PR TITLE
Remove unused vault.clientToken value

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -506,10 +506,6 @@ concourse:
       ##
       insecureSkipVerify: false
 
-      ## Client token for accessing secrets within the Vault server.
-      ##
-      clientToken:
-
       ## Time after which to force a reLogin. If not set, the token will just be continuously renewed.
       ##
       authBackendMaxTtl:


### PR DESCRIPTION
# Why do we need this PR?
Unused `concourse.web.vault.clientToken` value can lead to misconfiguration - I expected this value to be the one that configures the client token but it is actually `secrets.valueClientToken`


# Changes proposed in this pull request
Delete unused value


# Contributor Checklist
- [ ] ~Variables are documented in the `README.md`~
- [x] Which branch are you merging into? master

# Reviewer Checklist
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
