### PR TITLE
switch over to bitnami registry for dependency and update pg subchart…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,7 @@ in concourse/concourse#5141 (part of 6.0), riemann was completely removed, makin
 
 - To configure Concourse to use containerd as a runtime, set `concourse.worker.runtime` to `containerd`. In past versions of the chart, this was set in `concourse.worker.garden.useContainerd`, which was removed. Any containerd configuration should now be set under `concourse.worker.containerd.*` rather than under `concourse.worker.garden.*`. The default value for `concourse.worker.runtime` is `guardian`.
 - Note: v12.0.0 has no changes from v11.0.0 - please use the patch version v12.0.1 instead
+
+# v13.0.0:
+
+- upgraded the PostgreSQL Chart (direct dependency of this Chart) from `6.5.5` to `9.2.0`. As the backward compatibility is not guarantee when upgrading the PostgreSQL chart to this major version, a major bump was needed. Please refer to [PostgreSQL Chart](https://github.com/bitnami/charts/tree/master/bitnami/postgresql#upgrade) for details.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 13.0.0
+version: 12.0.2
 appVersion: 6.5.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 12.0.2
+version: 13.0.0
 appVersion: 6.5.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ web:
 
 ### PostgreSQL
 
-By default, this chart uses a PostgreSQL database deployed as a chart dependency (see the [PostgreSQL chart](https://github.com/helm/charts/blob/master/stable/postgresql/README.md)), with default values for username, password, and database name. These can be modified by setting the `postgresql.*` values.
+By default, this chart uses a PostgreSQL database deployed as a chart dependency (see the [PostgreSQL chart](https://github.com/bitnami/charts/blob/master/bitnami/postgresql/README.md)), with default values for username, password, and database name. These can be modified by setting the `postgresql.*` values.
 
 You can also bring your own PostgreSQL. To do so, set `postgresql.enabled` to `false`, and then configure Concourse's `postgres` values (`concourse.web.postgres.*`).
 

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.5.5
-digest: sha256:25655b1d890ab9555c02d53f7e32af63e577a8e3d0100215bec99c3a20b2a581
-generated: "2019-11-05T12:06:42.391348432+01:00"
+  repository: https://charts.bitnami.com/bitnami
+  version: 9.2.0
+digest: sha256:5082c9ee31559622b64a7391ad9d2f8cf8488a0d34ff03fb1600dfac5f3d89e2
+generated: "2020-08-28T15:21:20.204476-04:00"

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: postgresql
-  version: 6.5.5
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 9.2.0
+  repository: https://charts.bitnami.com/bitnami
   condition: postgresql.enabled


### PR DESCRIPTION
# Existing Issue

Fixes #118  .

# Why do we need this PR?

Current PostgreSQL subchart is pulled from a [deprecated repository](https://github.com/helm/charts/blob/master/stable/postgresql/README.md). Besides, it is referencing an outdated version of the chart.

# Changes proposed in this pull request

This PR: 

* switches over from `https://kubernetes-charts.storage.googleapis.com/` to [Bitnami's registry](https://charts.bitnami.com/bitnami) for PostgreSQL dependency.
* updates the PostgreSQL subchart from version `6.5.5` to version `9.2.0` which corresponds to Postgresql app version `11.8` (version that has been used in [Concourse tests](https://storage.cloud.google.com/concourse-components-version/postgresql-version-6.5.1.txt)). 

# Contributor Checklist

~- [ ] Variables are documented in the `README.md`~
- [x] Which branch are you merging into?
    - `master`


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
