### PR TITLE
Clarify comments in values.yml

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -856,7 +856,7 @@ concourse:
 
         ## List of local Concourse users to be included as members of the `main` team.
         ## Make sure you have local users support enabled (`concourse.web.localAuth.enabled`) and
-        ## that the users were added (`local-users` secret).
+        ## that the users were added (`secrets.localUsers`).
         ##
         localUser: "test"
 
@@ -2259,6 +2259,7 @@ secrets:
   teamAuthorizedKeys:
 
   ## List of `username:password` or `username:bcrypted_password` combinations for all your local concourse users.
+  ## For details of expected format, see https://concourse-ci.org/local-auth.html 
   ##
   localUsers: "test:test"
 


### PR DESCRIPTION
# Existing Issue
Partially fixes #145.


# Changes proposed in this pull request
* Refer to the key in `values.yml` where local users are set (rather than the eventual name of the Kubernetes secret)
* Add a link to Concourse docs where list format is described more fully

# Contributor Checklist

- [x] Variables are documented in the `README.md`



# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
