### PR TITLE
fix: Add quotations to garden max containers

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -244,7 +244,7 @@ Return concourse environment variables for worker configuration
 {{- end }}
 {{- if .Values.concourse.worker.garden.maxContainers }}
 - name: CONCOURSE_GARDEN_MAX_CONTAINERS
-  value: {{ .Values.concourse.worker.garden.maxContainers }}
+  value: {{ .Values.concourse.worker.garden.maxContainers | quote }}
 {{- end }}
 {{- if .Values.concourse.worker.garden.networkPool }}
 - name: CONCOURSE_GARDEN_NETWORK_POOL

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -276,7 +276,7 @@ Return concourse environment variables for worker configuration
 {{- end }}
 {{- if .Values.concourse.worker.containerd.maxContainers }}
 - name: CONCOURSE_CONTAINERD_MAX_CONTAINERS
-  value: {{ .Values.concourse.worker.containerd.maxContainers }}
+  value: {{ .Values.concourse.worker.containerd.maxContainers | quote }}
 {{- end }}
 {{- if .Values.concourse.worker.containerd.networkPool }}
 - name: CONCOURSE_CONTAINERD_NETWORK_POOL


### PR DESCRIPTION
# Existing Issue
N/A

# Why do we need this PR?
Fixes an issue highlighted when we ran our hrval linter

# Changes proposed in this pull request
* Add quotations around `concourse.worker.garden.maxContainers` value 


# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [x] Variables are documented in the `README.md` **N/A**
- [x] Which branch are you merging into? **master**


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
