### PR TITLE
fixes 160 clusterip values

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.service.api.NodePort` | Sets the nodePort for api when using `NodePort` | `nil` |
 | `web.service.api.labels` | Additional concourse web api service labels | `nil` |
 | `web.service.api.loadBalancerIP` | The IP to use when web.service.api.type is LoadBalancer | `nil` |
-| `web.service.api.clusterIP` | The IP to use when web.service.api.type is ClusterIP | `None` |
+| `web.service.api.clusterIP` | The IP to use when web.service.api.type is ClusterIP | `nil` |
 | `web.service.api.loadBalancerSourceRanges` | Concourse Web API Service Load Balancer Source IP ranges | `nil` |
 | `web.service.api.tlsNodePort` | Sets the nodePort for api tls when using `NodePort` | `nil` |
 | `web.service.api.type` | Concourse Web API service type | `ClusterIP` |

--- a/values.yaml
+++ b/values.yaml
@@ -309,7 +309,6 @@ concourse:
     ##
     logClusterName:
 
-
     ## Interval on which to run build tracking.
     ##
     buildTrackerInterval: 10s
@@ -1833,7 +1832,7 @@ web:
       ## When using `web.service.api.type: ClusterIP`, sets the user-specified cluster IP.
       ## Example: 172.217.1.174
       ##
-      clusterIP: None
+      clusterIP: 
 
       ## When using `web.service.api.type: LoadBalancer`, sets the user-specified load balancer IP.
       ## Example: 172.217.1.174


### PR DESCRIPTION
# Existing Issue

Fixes #160 160

# Why do we need this PR?

# Changes proposed in this pull request

* Change default value of web.clusterip

# Contributor Checklist
- [X ] Variables are documented in the `README.md`
- [dev] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
