### PR TITLE
add ability to configure SecurityContext for web container

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -51,9 +51,6 @@ spec:
       initContainers:
       {{- toYaml .Values.web.extraInitContainers | nindent 8 }}
       {{- end }}
-      {{- if .Values.web.dangerousAdditionalPodSpecFields }}
-      {{- toYaml .Values.web.dangerousAdditionalPodSpecFields | nindent 6 }}
-      {{- end }}
       containers:
       {{- if .Values.web.sidecarContainers }}
       {{- toYaml .Values.web.sidecarContainers | nindent 8 }}
@@ -1403,6 +1400,10 @@ spec:
             - name: auth-keys
               mountPath: {{ .Values.web.authSecretsPath | quote }}
               readOnly: true
+          {{- if .Values.web.securityContext }}
+          securityContext:
+          {{- toYaml .Values.web.securityContext | nindent 12 }}
+          {{- end }}
 {{- if .Values.web.additionalAffinities }}
       affinity:
 {{ toYaml .Values.web.additionalAffinities | indent 8 }}

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -51,6 +51,9 @@ spec:
       initContainers:
       {{- toYaml .Values.web.extraInitContainers | nindent 8 }}
       {{- end }}
+      {{- if .Values.web.dangerousAdditionalPodSpecFields }}
+      {{- toYaml .Values.web.dangerousAdditionalPodSpecFields | nindent 6 }}
+      {{- end }}
       containers:
       {{- if .Values.web.sidecarContainers }}
       {{- toYaml .Values.web.sidecarContainers | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -1645,7 +1645,6 @@ concourse:
 ## Concourse Web nodes, see https://concourse-ci.org/concourse-web.html.
 ##
 web:
-
   ## Enable or disable the web component.
   ## This allows the creation of worker-only releases by setting this to false.
   ##
@@ -1728,6 +1727,19 @@ web:
   ##     value: "debug"
   ##
   env:
+
+  ## Configure additional fields for the Pod spec
+  ## This provides a way to add arbitrary fields to the pod spec, this could be
+  ## useful to configure things that are not necessarily supported by the current
+  ## chart version
+  ## Warning: this could be dangerous and you should know what you're doing
+  ## Example:
+  ##   securityContext:
+  ##     capabilities:
+  ##       add:
+  ##         - SYS_PTRACE
+  ##
+  dangerousAdditionalPodSpecFields:
 
   ## Where secrets should be mounted for the web container.
   ##
@@ -1937,9 +1949,6 @@ web:
       ##
       ##
       annotations: {}
-
-
-
 
   ## Ingress configuration.
   ## Ref: https://kubernetes.io/docs/user-guide/ingress/

--- a/values.yaml
+++ b/values.yaml
@@ -1728,18 +1728,13 @@ web:
   ##
   env:
 
-  ## Configure additional fields for the Pod spec
-  ## This provides a way to add arbitrary fields to the pod spec, this could be
-  ## useful to configure things that are not necessarily supported by the current
-  ## chart version
-  ## Warning: this could be dangerous and you should know what you're doing
+  ## Configure the security context for the web containers.
   ## Example:
-  ##   securityContext:
-  ##     capabilities:
-  ##       add:
-  ##         - SYS_PTRACE
+  ##   capabilities:
+  ##     add:
+  ##       - SYS_PTRACE
   ##
-  dangerousAdditionalPodSpecFields:
+  securityContext:
 
   ## Where secrets should be mounted for the web container.
   ##


### PR DESCRIPTION
Applies only to the `web` container on the `web-deployment` pod, useful for stuff like attaching a live debugger to the process.