### PR TITLE
Allow enabling process namespace sharing for the web nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.service.workerGateway.type` | Concourse Web workerGateway service type | `ClusterIP` |
 | `web.service.prometheus.annotations` | Concourse Web Prometheus Service annotations | `nil` |
 | `web.service.prometheus.labels` | Additional concourse web prometheus service labels | `nil` |
+| `web.shareProcessNamespace` | Enable or disable the process namespace sharing for the web nodes | `false` |
 | `web.sidecarContainers` | Array of extra containers to run alongside the Concourse web container | `nil` |
 | `web.extraInitContainers` | Array of extra init containers to run before the Concourse web container | `nil` |
 | `web.strategy` | Strategy for updates to deployment. | `{}` |

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -51,6 +51,9 @@ spec:
       initContainers:
       {{- toYaml .Values.web.extraInitContainers | nindent 8 }}
       {{- end }}
+      {{- if .Values.web.shareProcessNamespace }}
+      shareProcessNamespace: true
+      {{- end }}
       containers:
       {{- if .Values.web.sidecarContainers }}
       {{- toYaml .Values.web.sidecarContainers | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -1687,6 +1687,14 @@ web:
   ##
   extraInitContainers: []
 
+  ## Enable or disable the process namespace sharing for the web nodes.
+  ## This allows signaling the concourse process from a sidecar container.
+  ## eg.: signal concourse web to reload the team authorized keys file.
+  ##
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+  ##
+  shareProcessNamespace: false
+
   ## Configures the liveness probe used to determine if the Web component is up.
   ## ps.: if you're upgrading Concourse from one version  to another, the probe will
   ## probably fail for some time before migrations are finished - in such situations,


### PR DESCRIPTION
# Why do we need this PR?

Since concourse/concourse#5652, it is possible to send a `SIGHUP` signal to the TSA to reload worker authorized keys without restarting the concourse server.

In order to use that feature with the concourse helm chart, one correct Kubernetes way to achieve that is to add a sidecar container responsible to update the team authorized keys file from whatever source, and then send the `SIGHUP` signal to Concourse in order to take the update into account.

That being said, to be able to send a `SIGHUP` signal between containers within a pod, the `shareProcessNamespace` field of `v1.PodSpec` needs to be set to `true`.

This PR implements a new parameter in the chart in order to enable that process namespace sharing capability for the web component.

At Cycloid, we participated in the implementation of this feature within Concourse and use it successfully to authorize worker keys fetched from a Vault server.
This PR would let us use the official helm chart for our Concourse deployments.

# Changes proposed in this pull request

* Add option to enable process namespace sharing between containers within the web component.

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [x] Variables are documented in the `README.md`
- [x] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [x] Code reviewed
- [x] Topgun tests run
- [ ] Back-port if needed
- [x] Is the correct branch targeted? (`master` or `dev`)
