### PR TITLE
Helm unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test
 
 test:
-	helm unittest -f 'unit-tests/*.yaml' ./ --helm3
+	helm unittest --helm3 -f 'unit-tests/*.yaml' ./
 
 template:
 	helm template test ./ > rendered.yaml

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ test:
 	helm unittest --helm3 -f 'unit-tests/*.yaml' ./
 
 template:
-	helm template test ./ > rendered.yaml
+	helm template release-name ./ > rendered.yaml
 
 install-unittest:
 	helm plugin install https://github.com/quintush/helm-unittest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: test
+
+test:
+	helm unittest -f 'unit-tests/*.yaml' ./ --helm3
+
+template:
+	helm template test ./ > rendered.yaml
+
+install-unittest:
+	helm plugin install https://github.com/quintush/helm-unittest

--- a/README.md
+++ b/README.md
@@ -672,13 +672,25 @@ When adding a new Concourse flag, don't assign a `default` value in the `values.
 
 Instead, you may add a comment specifying the default, such as
 
-  ```
-      ## pipeline-specific template for SSM parameters, defaults to: /concourse/{{.Team}}/{{.Pipeline}}/{{.Secret}}
-      ##
-      pipelineSecretTemplate:
+```
+  ## pipeline-specific template for SSM parameters, defaults to: /concourse/{{.Team}}/{{.Pipeline}}/{{.Secret}}
+  ##
+  pipelineSecretTemplate:
 
-  ``` 
+```
+or an example, such as
+```
+  ## When using `web.service.api.type: ClusterIP`, sets the user-specified cluster IP.
+  ## Example: 172.217.1.174
+  ##
+  clusterIP: None
+```
 
 This prevents the behaviour drifting from that of the binary in case the binary's default values change.
   
 We understand that the comment stating the binary's default can become stale. The current solution is a suboptimal one. It may be improved in the future by generating a list of the default values from the binary.
+
+To run the unit tests use the `Makefile`
+```
+make test
+```

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -11,7 +11,8 @@ metadata:
 spec:
   replicas: {{ .Values.web.replicas }}
 {{- if .Values.web.strategy }}
-{{ toYaml .Values.web.strategy | indent 2 }}
+  strategy:
+{{ toYaml .Values.web.strategy | indent 4 }}
 {{- end }}
   selector:
     matchLabels:

--- a/unit-tests/required-check-test.yaml
+++ b/unit-tests/required-check-test.yaml
@@ -9,6 +9,7 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "Must set either web.enabled or worker.enabled to create a concourse deployment"
+
   - it: should return an error if TSA host is not set in a worker only deployment
     set:
       web.enabled: false

--- a/unit-tests/required-check-test.yaml
+++ b/unit-tests/required-check-test.yaml
@@ -1,0 +1,18 @@
+suite: Required Checks
+templates:
+  - required-check.yaml
+tests:
+  - it: should return an error if web and worker are disabled
+    set:
+      web.enabled: false
+      worker.enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "Must set either web.enabled or worker.enabled to create a concourse deployment"
+  - it: should return an error if TSA host is not set in a worker only deployment
+    set:
+      web.enabled: false
+      worker.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "concourse.worker.tsa.hosts must be set in case of worker only deployment"

--- a/unit-tests/web-deployment-test.yaml
+++ b/unit-tests/web-deployment-test.yaml
@@ -16,12 +16,10 @@ tests:
           value: apps/v1
 
   - it: metadata contains
-    release:
-      name: release
     asserts:
       - equal:
           path: metadata.name
-          value: release-web
+          value: RELEASE-NAME-web
       - isNotEmpty:
           path: metadata.labels.chart
       - isNotEmpty:
@@ -62,27 +60,243 @@ tests:
           path: spec.strategy.rollingUpdate
 
   - it: renders matchLabels
-    release:
-      name: release
     asserts:
       - equal:
           path: spec.selector.matchLabels.app
-          value: release-web
+          value: RELEASE-NAME-web
       - equal:
           path: spec.selector.matchLabels.release
-          value: release
+          value: RELEASE-NAME
 
   - it: renders template metadata
-    release:
-      name: release
+    set:
+      web.labels:
+        label1: value1
+        label2: value2
+      web.annotations:
+        annot1: value1
+        annot2: value2
     asserts:
       - equal:
-          path: spec.template.metadata.labels.app
-          value: release-web
+          path: spec.template.metadata.labels
+          value:
+            app: RELEASE-NAME-web
+            release: RELEASE-NAME
+            label1: value1
+            label2: value2
       - equal:
-          path: spec.template.metadata.labels.release
-          value: release
+          path: spec.template.metadata.annotations.annot1
+          value: value1
+      - equal:
+          path: spec.template.metadata.annotations.annot2
+          value: value2
       - isNotEmpty:
           path: spec.template.metadata.annotations.checksum/secrets
       - isNotEmpty:
           path: spec.template.metadata.annotations.checksum/config
+
+
+  # Spec tests
+  #
+  - it: renders nodeSelector
+    set:
+      web.nodeSelector:
+        key1: value1
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            key1: value1
+
+  - it: renders serviceAccountName when rbac creation is disabled
+    set:
+      rbac.create: false
+      rbac.webServiceAccountName: rbacAccount
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: rbacAccount
+
+  - it: renders web fullname as rbac service account
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-web
+
+  - it: renders tolerations
+    set:
+      web.tolerations:
+        - key: "toleration=key"
+          operator: "Equal"
+          value: "value"
+          effect: "NoSchedule"
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - key: "toleration=key"
+              operator: "Equal"
+              value: "value"
+              effect: "NoSchedule"
+
+  - it: renders imagePullSecrets
+    set:
+      imagePullSecrets:
+        - secret1
+        - secret2
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: secret1
+            - name: secret2
+
+  - it: renders extraInitContainers
+    set:
+      web.extraInitContainers:
+        - name: init-1
+          image: alpine
+          command: ['sh', '-c', 'echo Hello World']
+        - name: init-2
+          image: busybox
+          command:
+            - sh
+            - -c
+            - |
+              echo hello world!
+              sleep 10
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers
+          value:
+            - name: init-1
+              image: alpine
+              command: ['sh', '-c', 'echo Hello World']
+            - name: init-2
+              image: busybox
+              command:
+                - sh
+                - -c
+                - |
+                  echo hello world!
+                  sleep 10
+
+  - it: renders containers and sidecarContainers
+    set:
+      imageTag: "4.4.4"
+      web.sidecarContainers:
+        - name: init-1
+          image: alpine
+          command: ['sh', '-c', 'echo Hello World']
+        - name: init-2
+          image: busybox
+          command:
+            - sh
+            - -c
+            - |
+              echo hello world!
+              sleep 10
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0]
+          value:
+            name: init-1
+            image: alpine
+            command: ['sh', '-c', 'echo Hello World']
+      - equal:
+          path: spec.template.spec.containers[1]
+          value:
+            name: init-2
+            image: busybox
+            command:
+              - sh
+              - -c
+              - |
+                echo hello world!
+                sleep 10
+      # main concourse container splt into multiple asserts because all the env
+      # vars that render would make this test really long
+      - equal:
+          path: spec.template.spec.containers[2].name
+          value: RELEASE-NAME-web
+      - equal:
+          path: spec.template.spec.containers[2].image
+          value: "concourse/concourse:4.4.4"
+      - equal:
+          path: spec.template.spec.containers[2].imagePullPolicy
+          value: IfNotPresent
+      - equal:
+          path: spec.template.spec.containers[2].args
+          value: ["web"]
+
+  - it: renders default ports
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: atc
+            containerPort: 8080
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: tsa
+            containerPort: 2222
+
+  - it: renders custom/non-default ports
+    set:
+      concourse.web.tls.enabled: true
+      secrets.webTlsCert: fakecert
+      secrets.webTlsKey: fakekey
+      concourse.web.externalUrl: url
+      concourse.web.debugBindPort: 1111
+      concourse.web.tsa.bindDebugPort: 1234
+      concourse.web.prometheus.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: atc-tls
+            containerPort: 443
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: atc-debug
+            containerPort: 1111
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: tsa-debug
+            containerPort: 1234
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: prometheus
+            containerPort: 9391
+
+  - it: renders the liveness and readiness probes
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            failureThreshold: 5
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 3
+            httpGet:
+              path: /api/v1/info
+              port: atc
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            httpGet:
+              path: /api/v1/info
+              port: atc
+
+  - it: renders resouces
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"

--- a/unit-tests/web-deployment-test.yaml
+++ b/unit-tests/web-deployment-test.yaml
@@ -1,0 +1,88 @@
+suite: Web Deployment
+templates:
+  - web-deployment.yaml
+tests:
+  - it: should render by default
+    capabilities:
+      # 1.9.0
+      minorVersion: 9
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+         of: Deployment
+      - equal:
+          path: apiVersion
+          value: apps/v1
+
+  - it: metadata contains
+    release:
+      name: release
+    asserts:
+      - equal:
+          path: metadata.name
+          value: release-web
+      - isNotEmpty:
+          path: metadata.labels.chart
+      - isNotEmpty:
+          path: metadata.labels.release
+      - isNotEmpty:
+          path: metadata.labels.heritage
+
+  - it: fullnameOverride is used
+    set:
+      fullnameOverride: fullOverride
+      web.nameOverride: webOverride
+    asserts:
+      - equal:
+          path: metadata.name
+          value: fullOverride-webOverride
+
+  - it: has specified replicas
+    set:
+      web.replicas: 5
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 5
+
+  - it: renders the strategy
+    set:
+      web.strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 25%
+    asserts:
+      - isNotEmpty:
+          path: spec.strategy
+      - isNotEmpty:
+          path: spec.strategy.type
+      - isNotEmpty:
+          path: spec.strategy.rollingUpdate
+
+  - it: renders matchLabels
+    release:
+      name: release
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: release-web
+      - equal:
+          path: spec.selector.matchLabels.release
+          value: release
+
+  - it: renders template metadata
+    release:
+      name: release
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.app
+          value: release-web
+      - equal:
+          path: spec.template.metadata.labels.release
+          value: release
+      - isNotEmpty:
+          path: spec.template.metadata.annotations.checksum/secrets
+      - isNotEmpty:
+          path: spec.template.metadata.annotations.checksum/config

--- a/unit-tests/web-deployment-test.yaml
+++ b/unit-tests/web-deployment-test.yaml
@@ -2,7 +2,7 @@ suite: Web Deployment
 templates:
   - web-deployment.yaml
 tests:
-  - it: should render by default
+  - it: should render successfully with default values.yaml
     capabilities:
       # 1.9.0
       minorVersion: 9
@@ -15,7 +15,7 @@ tests:
           path: apiVersion
           value: apps/v1
 
-  - it: metadata contains
+  - it: metadata should be populated
     asserts:
       - equal:
           path: metadata.name
@@ -52,12 +52,13 @@ tests:
           maxSurge: 1
           maxUnavailable: 25%
     asserts:
-      - isNotEmpty:
+      - equal:
           path: spec.strategy
-      - isNotEmpty:
-          path: spec.strategy.type
-      - isNotEmpty:
-          path: spec.strategy.rollingUpdate
+          value:
+            type: RollingUpdate
+            rollingUpdate:
+              maxSurge: 1
+              maxUnavailable: 25%
 
   - it: renders matchLabels
     asserts:
@@ -96,7 +97,7 @@ tests:
           path: spec.template.metadata.annotations.checksum/config
 
 
-  # Spec tests
+  # Template.Spec tests
   #
   - it: renders nodeSelector
     set:


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to the Concourse Helm chart!
If you haven't already, please take a look at our [Code of Conduct](https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md).

To help us review your PR, please fill in the following information.
Feel free to delete any sections not applicable to your pull request.
-->

# Existing Issue
Fixes #174 

# Why do we need this PR?
We want to stop using topgun/k8s for testing the chart. This starts moving us towards that direction.

# Changes proposed in this pull request
Add a folder called `unit-tests` that uses the `unittest` helm plugin from https://github.com/quintush/helm-unittest. After installing the plugin (run `make install-unittest`) you can run the tests by running `make test` in the root of this repo.

The only unit tests are for the web-deployment and required-check templates. Looking for feedback on the tests written so far and see if this is something we want to keep building/working on.

This also fixes one bug where `web-deployment` was not rendering `strategy` correctly from `values.yam`.

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [ ] ~Variables are documented in the `README.md`~
- [x] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
