### PR TITLE
Fix tutorials link in helm NOTES

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -33,7 +33,7 @@
     kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:{{ .Values.concourse.web.bindPort }}
     {{- end }}
   {{- end }}
-* If this is your first time using Concourse, follow the tutorials at https://concourse-ci.org/tutorials.html
+* If this is your first time using Concourse, follow the examples at https://concourse-ci.org/examples.html
 
 {{- if .Values.worker.enabled }}
 {{- if .Values.concourse.worker.baggageclaim.driver }}


### PR DESCRIPTION
# Existing Issue

Fixes #179 .

# Why do we need this PR?

The tutorials in NOTES was throwing a 404, changed to examples - https://concourse-ci.org/examples.html

# Changes proposed in this pull request

* change link to examples https://concourse-ci.org/examples.html

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [ ] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
