### PR TITLE
Fixes issue with disabling external worker

### DIFF
--- a/templates/web-worker-gateway-svc.yaml
+++ b/templates/web-worker-gateway-svc.yaml
@@ -38,6 +38,8 @@ spec:
       targetPort: tsa
       {{- if and (eq "NodePort" .Values.web.service.workerGateway.type) .Values.web.service.workerGateway.NodePort }}
       nodePort: {{ .Values.web.service.workerGateway.NodePort}}
+      {{- else}}
+      nodePort: null
       {{- end }}
   selector:
     app: {{ template "concourse.web.fullname" . }}


### PR DESCRIPTION
Changing from type LoadBalancer to ClusterIP was not clearing the nodePort settings. This results in the service not being updated.


```
UPGRADE FAILED: cannot patch "test-web-worker-gateway" with kind Service: Service "test-web-worker-gateway" is invalid: spec.ports[0].nodePort: Forbidden: may not be used when `type` is 'ClusterIP'
```
