### PR TITLE
Add baggageclaim p2p volume streaming flags

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -338,5 +338,13 @@ Return concourse environment variables for worker configuration
 - name: CONCOURSE_CONTAINER_SWEEPER_MAX_IN_FLIGHT
   value: {{ .Values.concourse.worker.containerSweeperMaxInFlight | quote }}
 {{- end -}}
+{{- if .Values.concourse.worker.p2pInterfaceFamily }}
+- name: CONCOURSE_BAGGAGECLAIM_P2P_INTERFACE_FAMILY
+  value: {{ .Values.concourse.worker.p2pInterfaceFamily }}
+{{- end -}}
+{{- if .Values.concourse.worker.p2pInterfacePattern }}
+- name: CONCOURSE_BAGGAGECLAIM_P2P_INTERFACE_NAME_PATTERN
+  value: {{ .Values.concourse.worker.p2pInterfacePattern | quote }}
+{{- end -}}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -342,9 +342,9 @@ Return concourse environment variables for worker configuration
 - name: CONCOURSE_BAGGAGECLAIM_P2P_INTERFACE_FAMILY
   value: {{ .Values.concourse.worker.baggageclaim.p2pInterfaceFamily }}
 {{- end }}
-{{- if .Values.concourse.worker.baggageclaim.p2pInterfacePattern }}
+{{- if .Values.concourse.worker.baggageclaim.p2pInterfaceNamePattern }}
 - name: CONCOURSE_BAGGAGECLAIM_P2P_INTERFACE_NAME_PATTERN
-  value: {{ .Values.concourse.worker.baggageclaim.p2pInterfacePattern | quote }}
+  value: {{ .Values.concourse.worker.baggageclaim.p2pInterfaceNamePattern | quote }}
 {{- end -}}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -207,10 +207,10 @@ Return concourse environment variables for worker configuration
 - name: CONCOURSE_LOG_LEVEL
   value: {{ .Values.concourse.worker.logLevel | quote }}
 {{- end }}
-{{ if not .Values.web.enabled }}
+{{- if not .Values.web.enabled }}
 - name: CONCOURSE_TSA_HOST
   value: "{{- range $i, $tsaHost := .Values.concourse.worker.tsa.hosts }}{{- if $i }},{{ end }}{{- $tsaHost }}{{- end -}}"
-{{ else }}
+{{- else }}
 - name: CONCOURSE_TSA_HOST
   value: "{{ template "concourse.web.tsa.address" . -}}"
 {{- end }}
@@ -337,14 +337,14 @@ Return concourse environment variables for worker configuration
 {{- if .Values.concourse.worker.containerSweeperMaxInFlight }}
 - name: CONCOURSE_CONTAINER_SWEEPER_MAX_IN_FLIGHT
   value: {{ .Values.concourse.worker.containerSweeperMaxInFlight | quote }}
-{{- end -}}
-{{- if .Values.concourse.worker.p2pInterfaceFamily }}
+{{- end }}
+{{- if .Values.concourse.worker.baggageclaim.p2pInterfaceFamily }}
 - name: CONCOURSE_BAGGAGECLAIM_P2P_INTERFACE_FAMILY
-  value: {{ .Values.concourse.worker.p2pInterfaceFamily }}
-{{- end -}}
-{{- if .Values.concourse.worker.p2pInterfacePattern }}
+  value: {{ .Values.concourse.worker.baggageclaim.p2pInterfaceFamily }}
+{{- end }}
+{{- if .Values.concourse.worker.baggageclaim.p2pInterfacePattern }}
 - name: CONCOURSE_BAGGAGECLAIM_P2P_INTERFACE_NAME_PATTERN
-  value: {{ .Values.concourse.worker.p2pInterfacePattern | quote }}
+  value: {{ .Values.concourse.worker.baggageclaim.p2pInterfacePattern | quote }}
 {{- end -}}
 {{- end -}}
 

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -102,6 +102,10 @@ spec:
             - name: CONCOURSE_ENABLE_SKIP_CHECKING_NOT_IN_USE_RESOURCES
               value: {{ .Values.concourse.web.enableSkipCheckingNotInUseResources | quote }}
             {{- end }}
+            {{- if .Values.concourse.web.enablep2pVolumeStreaming }}
+            - name: CONCOURSE_ENABLE_P2P_VOLUME_STREAMING
+              value: {{ .Values.concourse.web.enablep2pVolumeStreaming | quote }}
+            {{- end }}
             {{- if .Values.concourse.web.jobSchedulingMaxInFlight }}
             - name: CONCOURSE_JOB_SCHEDULING_MAX_IN_FLIGHT
               value: {{ .Values.concourse.web.jobSchedulingMaxInFlight | quote }}
@@ -297,6 +301,10 @@ spec:
             {{- if .Values.concourse.web.globalResourceCheckTimeout }}
             - name: CONCOURSE_GLOBAL_RESOURCE_CHECK_TIMEOUT
               value: {{ .Values.concourse.web.globalResourceCheckTimeout | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.p2pVolumeStreamingTimeout }}
+            - name: CONCOURSE_P2P_VOLUME_STREAMING_TIMEOUT
+              value: {{ .Values.concourse.web.p2pVolumeStreamingTimeout | quote }}
             {{- end }}
             {{- if .Values.concourse.web.maxChecksPerSecond }}
             - name: CONCOURSE_MAX_CHECKS_PER_SECOND

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -77,7 +77,7 @@ spec:
                 command:
                   - "/bin/bash"
                   - "/pre-stop-hook.sh"
-          env: 
+          env:
 {{- include "concourse.worker.env" . | indent 12 }}
 {{- if .Values.worker.env }}
 {{ toYaml .Values.worker.env | indent 12 }}

--- a/values.yaml
+++ b/values.yaml
@@ -99,6 +99,11 @@ concourse:
     ##
     enableSkipCheckingNotInUseResources: false
 
+    ## Enable P2P volume streaming between all wokrers.
+    ## By default all volume streming goes through the web nodes.
+    ##
+    enablep2pVolumeStreaming: false
+
     ## Maximum number of jobs to be scheduling at the same time.
     ##
     jobSchedulingMaxInFlight:
@@ -256,6 +261,10 @@ concourse:
     ## Time limit on checking for new versions of resources.
     ##
     globalResourceCheckTimeout: 1h
+
+    ## Time limit on P2P volume streaming
+    ##
+    p2pVolumeStreamingTimeout:
 
     ## Maximum number of checks that can be started per second. If not
     ## specified, # this will be calculated as (# of resources)/(resource
@@ -1611,6 +1620,15 @@ concourse:
       ## Interval on which to reap expired volumes.
       ##
       reapInterval: 10s
+
+      ## 4 for IPv4 and 6 for IPv6
+      ##
+      p2pInterfaceFamily:
+
+      ## Regular expression to match a network interface for p2p streaming
+      ## e.g. "eth0"
+      ##
+      p2pInterfacePattern:
 
     ## Enable Horizontal Pod Autoscaling
     ## to use this, ephemeral worker with

--- a/values.yaml
+++ b/values.yaml
@@ -1628,7 +1628,7 @@ concourse:
       ## Regular expression to match a network interface for p2p streaming
       ## e.g. "eth0"
       ##
-      p2pInterfacePattern:
+      p2pInterfaceNamePattern:
 
     ## Enable Horizontal Pod Autoscaling
     ## to use this, ephemeral worker with


### PR DESCRIPTION
# Existing Issue

Fixes CI 


# Changes proposed in this pull request
Adds the following flags/envs:

```
CONCOURSE_BAGGAGECLAIM_P2P_INTERFACE_FAMILY

CONCOURSE_BAGGAGECLAIM_P2P_INTERFACE_NAME_PATTERN

CONCOURSE_ENABLE_P2P_VOLUME_STREAMING

CONCOURSE_P2P_VOLUME_STREAMING_TIMEOUT

```

# Contributor Checklist
- [ ] ~Variables are documented in the `README.md`~ We don't document web/worker flags, only k8s config flags
- [x] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
