### PR TITLE
Run db migrations in init container

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -207,10 +207,10 @@ Return concourse environment variables for worker configuration
 - name: CONCOURSE_LOG_LEVEL
   value: {{ .Values.concourse.worker.logLevel | quote }}
 {{- end }}
-{{ if not .Values.web.enabled }}
+{{- if not .Values.web.enabled }}
 - name: CONCOURSE_TSA_HOST
   value: "{{- range $i, $tsaHost := .Values.concourse.worker.tsa.hosts }}{{- if $i }},{{ end }}{{- $tsaHost }}{{- end -}}"
-{{ else }}
+{{- else }}
 - name: CONCOURSE_TSA_HOST
   value: "{{ template "concourse.web.tsa.address" . -}}"
 {{- end }}
@@ -340,3 +340,68 @@ Return concourse environment variables for worker configuration
 {{- end -}}
 {{- end -}}
 
+{{/*
+Return concourse environment variables for postgresql configuration
+*/}}
+{{- define "concourse.postgresql.env" -}}
+{{- if .Values.postgresql.enabled }}
+- name: CONCOURSE_POSTGRES_HOST
+  value: {{ template "concourse.postgresql.fullname" . }}
+- name: CONCOURSE_POSTGRES_USER
+  value: {{ .Values.postgresql.postgresqlUsername | quote }}
+- name: CONCOURSE_POSTGRES_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ template "concourse.postgresql.fullname" . }}
+      key: postgresql-password
+- name: CONCOURSE_POSTGRES_DATABASE
+  value: {{ .Values.postgresql.postgresqlDatabase | quote }}
+{{- else }}
+{{- if .Values.concourse.web.postgres.host }}
+- name: CONCOURSE_POSTGRES_HOST
+  value: {{ .Values.concourse.web.postgres.host | quote }}
+{{- end }}
+{{- if .Values.concourse.web.postgres.port }}
+- name: CONCOURSE_POSTGRES_PORT
+  value: {{ .Values.concourse.web.postgres.port | quote }}
+{{- end }}
+{{- if .Values.concourse.web.postgres.socket }}
+- name: CONCOURSE_POSTGRES_SOCKET
+  value: {{ .Values.concourse.web.postgres.socket | quote }}
+{{- end }}
+- name: CONCOURSE_POSTGRES_USER
+  valueFrom:
+    secretKeyRef:
+      name: {{ template "concourse.web.fullname" . }}
+      key: postgresql-user
+- name: CONCOURSE_POSTGRES_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ template "concourse.web.fullname" . }}
+      key: postgresql-password
+{{- if .Values.concourse.web.postgres.sslmode }}
+- name: CONCOURSE_POSTGRES_SSLMODE
+  value: {{ .Values.concourse.web.postgres.sslmode | quote }}
+{{- end }}
+{{- if .Values.secrets.postgresCaCert }}
+- name: CONCOURSE_POSTGRES_CA_CERT
+  value: "{{ .Values.web.postgresqlSecretsPath }}/ca.cert"
+{{- end }}
+{{- if .Values.secrets.postgresClientCert }}
+- name: CONCOURSE_POSTGRES_CLIENT_CERT
+  value: "{{ .Values.web.postgresqlSecretsPath }}/client.cert"
+{{- end }}
+{{- if .Values.secrets.postgresClientKey }}
+- name: CONCOURSE_POSTGRES_CLIENT_KEY
+  value: "{{ .Values.web.postgresqlSecretsPath }}/client.key"
+{{- end }}
+{{- if .Values.concourse.web.postgres.connectTimeout }}
+- name: CONCOURSE_POSTGRES_CONNECT_TIMEOUT
+  value: {{ .Values.concourse.web.postgres.connectTimeout | quote }}
+{{- end }}
+{{- if .Values.concourse.web.postgres.database }}
+- name: CONCOURSE_POSTGRES_DATABASE
+  value: {{ .Values.concourse.web.postgres.database | quote }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -54,7 +54,7 @@ spec:
         {{- else }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         {{- end }}
-        command: ['concourse', 'migrate']
+        args: ["migrate"]
         env:
 {{- include "concourse.postgresql.env" . | indent 10 }}
       {{- if .Values.web.extraInitContainers }}

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -54,7 +54,7 @@ spec:
         {{- else }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         {{- end }}
-        args: ["migrate"]
+        args: ["migrate", "--migrate-to-latest-version"]
         env:
 {{- include "concourse.postgresql.env" . | indent 10 }}
       {{- if .Values.web.extraInitContainers }}

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -47,8 +47,17 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if .Values.web.extraInitContainers }}
       initContainers:
+      - name: concourse-migration
+        {{- if .Values.imageDigest }}
+        image: "{{ .Values.image }}@{{ .Values.imageDigest }}"
+        {{- else }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        {{- end }}
+        command: ['concourse', 'migrate']
+        env:
+{{- include "concourse.postgresql.env" . | indent 10 }}
+      {{- if .Values.web.extraInitContainers }}
       {{- toYaml .Values.web.extraInitContainers | nindent 8 }}
       {{- end }}
       {{- if .Values.web.shareProcessNamespace }}
@@ -370,66 +379,7 @@ spec:
             - name: CONCOURSE_DEFAULT_TASK_MEMORY_LIMIT
               value: {{ .Values.concourse.web.defaultTaskMemoryLimit | quote }}
             {{- end }}
-            {{- if .Values.postgresql.enabled }}
-            - name: CONCOURSE_POSTGRES_HOST
-              value: {{ template "concourse.postgresql.fullname" . }}
-            - name: CONCOURSE_POSTGRES_USER
-              value: {{ .Values.postgresql.postgresqlUsername | quote }}
-            - name: CONCOURSE_POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "concourse.postgresql.fullname" . }}
-                  key: postgresql-password
-            - name: CONCOURSE_POSTGRES_DATABASE
-              value: {{ .Values.postgresql.postgresqlDatabase | quote }}
-            {{- else }}
-            {{- if .Values.concourse.web.postgres.host }}
-            - name: CONCOURSE_POSTGRES_HOST
-              value: {{ .Values.concourse.web.postgres.host | quote }}
-            {{- end }}
-            {{- if .Values.concourse.web.postgres.port }}
-            - name: CONCOURSE_POSTGRES_PORT
-              value: {{ .Values.concourse.web.postgres.port | quote }}
-            {{- end }}
-            {{- if .Values.concourse.web.postgres.socket }}
-            - name: CONCOURSE_POSTGRES_SOCKET
-              value: {{ .Values.concourse.web.postgres.socket | quote }}
-            {{- end }}
-            - name: CONCOURSE_POSTGRES_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "concourse.web.fullname" . }}
-                  key: postgresql-user
-            - name: CONCOURSE_POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "concourse.web.fullname" . }}
-                  key: postgresql-password
-            {{- if .Values.concourse.web.postgres.sslmode }}
-            - name: CONCOURSE_POSTGRES_SSLMODE
-              value: {{ .Values.concourse.web.postgres.sslmode | quote }}
-            {{- end }}
-            {{- if .Values.secrets.postgresCaCert }}
-            - name: CONCOURSE_POSTGRES_CA_CERT
-              value: "{{ .Values.web.postgresqlSecretsPath }}/ca.cert"
-            {{- end }}
-            {{- if .Values.secrets.postgresClientCert }}
-            - name: CONCOURSE_POSTGRES_CLIENT_CERT
-              value: "{{ .Values.web.postgresqlSecretsPath }}/client.cert"
-            {{- end }}
-            {{- if .Values.secrets.postgresClientKey }}
-            - name: CONCOURSE_POSTGRES_CLIENT_KEY
-              value: "{{ .Values.web.postgresqlSecretsPath }}/client.key"
-            {{- end }}
-            {{- if .Values.concourse.web.postgres.connectTimeout }}
-            - name: CONCOURSE_POSTGRES_CONNECT_TIMEOUT
-              value: {{ .Values.concourse.web.postgres.connectTimeout | quote }}
-            {{- end }}
-            {{- if .Values.concourse.web.postgres.database }}
-            - name: CONCOURSE_POSTGRES_DATABASE
-              value: {{ .Values.concourse.web.postgres.database | quote }}
-            {{- end }}
-            {{- end }}
+{{- include "concourse.postgresql.env" . | indent 12 }}
             {{- if .Values.concourse.web.kubernetes.enabled }}
             - name: CONCOURSE_KUBERNETES_IN_CLUSTER
               value: "true"

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -77,7 +77,7 @@ spec:
                 command:
                   - "/bin/bash"
                   - "/pre-stop-hook.sh"
-          env: 
+          env:
 {{- include "concourse.worker.env" . | indent 12 }}
 {{- if .Values.worker.env }}
 {{ toYaml .Values.worker.env | indent 12 }}


### PR DESCRIPTION
implements https://github.com/concourse/concourse-chart/issues/194

BLOCKED: we learned the `concourse migrate` does not automatically migrate to the latest db version. You actually need to pass in one of the following flags:
```
--current-db-version
--supported-db-version
--migrate-db-to-version
```
We would need to script the migration process now in order to use this command. We're thinking of PR'ing a change concourse/concourse to make the migrate command migrate to the latest version by default or add a flag that will do that for us.

This PR should go into `dev` branch if we don't do the scripting option.

