### PR TITLE
Defaulting vault backend to `token`

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -502,10 +502,10 @@ concourse:
       ##
       useCaCert: false
 
-      ## Vault authentication backend, leave this blank if using an initial periodic token.
+      ## Vault authentication backend
       ## Currently supported backends: token, approle, cert.
-      ##
-      authBackend: ""
+      ## Use token if using an initial periodic token.
+      authBackend: token
 
       ## Path to a directory of PEMEncoded CA cert files to verify the vault server SSL cert.
       ##


### PR DESCRIPTION
# Why do we need this PR?

> Vault authentication backend, leave this blank if using an initial periodic token

The current comment on the property is inaccurate, as the initial periodic token is [not templated](https://github.com/concourse/concourse-chart/blob/d9fc598ea2d5c85df55291795988baa763cf0dea/templates/web-deployment.yaml#L529-L535) in and the webworker fails to start if the authBackend is not set

# Changes proposed in this pull request
Changes the default on the chart to be "token", which would enable the chart to work for initial periodic tokens be default, which is what the documented intent seems to be.

