### PR TITLE
Quota is mandatory on some platform, including init container.

### DIFF
--- a/templates/worker-statefulset.yaml
+++ b/templates/worker-statefulset.yaml
@@ -60,6 +60,10 @@ spec:
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
           {{- end }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+{{- if .Values.worker.init-resources }}
+          resources:
+{{ toYaml .Values.worker.resources | indent 12 }}
+{{- end }}
           securityContext:
             privileged: true
           command:


### PR DESCRIPTION
I tried to deploy an external concourse worker on
[DECC](https://devhub.eng.vmware.com/console/decc).

My space was set with a resource quota. An error will raise if the container
has no `resources` configuration, including the init container.

Signed-off-by: Bin Ju <bju@pivotal.io>

# Existing Issue
When I tried to deploy to DECC, I got the error:
```
 Warning  FailedCreate  82s (x12 over 94s)  statefulset-controller  create Pod workers-worker-0 in StatefulSet workers-worker failed error: pods "workers-worker-0" is forbidden: failed quota: scdc1-staging-cf-toolsmiths: must specify limits.cpu,limits.memory,requests.cpu,requests.memory
```
Fixes # .

# Why do we need this PR?
Enable user to configure `resources` for init container.

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
