### PR TITLE
add flag for skipping email verification

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: concourse
 type: application
 version: 14.0.3
-appVersion: 6.7.3
+appVersion: 6.7.5
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479
 keywords:

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -1237,6 +1237,10 @@ spec:
             - name: CONCOURSE_OIDC_DISABLE_GROUPS
               value: {{ .Values.concourse.web.auth.oidc.disableGroups | quote }}
             {{- end }}
+            {{- if .Values.concourse.web.auth.oidc.skipEmailVerifiedValidation }}
+            - name: CONCOURSE_OIDC_SKIP_EMAIL_VERIFIED_VALIDATION
+              value: {{ .Values.concourse.web.auth.oidc.skipEmailVerifiedValidation | quote }}
+            {{- end }}
             {{- end }}
 
             {{- if .Values.concourse.web.auth.microsoft.enabled }}

--- a/values.yaml
+++ b/values.yaml
@@ -21,7 +21,7 @@ image: concourse/concourse
 ##      of `concourse/concourse`.
 ## Ref: https://hub.docker.com/r/concourse/concourse/tags/
 ##
-imageTag: "6.7.3"
+imageTag: "6.7.5"
 
 ## Specific image digest to use in place of a tag.
 ## Ref: https://kubernetes.io/docs/concepts/configuration/overview/#container-images

--- a/values.yaml
+++ b/values.yaml
@@ -1300,6 +1300,11 @@ concourse:
         ##
         disableGroups:
 
+        ## Ignore the email_verified claim from the upstream provider, treating
+        ## all users as if email_verified were true.
+        ##
+        skipEmailVerifiedValidation:
+
       ## Authentication (Microsoft)
       microsoft:
         enabled: false


### PR DESCRIPTION
# Changes proposed in this pull request

* adds a flag for setting `CONCOURSE_OIDC_SKIP_EMAIL_VERIFIED_VALIDATION`
* bumps chart/app version and bumps the tag

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [ ] Variables are documented in the `README.md`
- [ ] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
