### PR TITLE
Fix ingress API group for >1.20 k8s

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -114,8 +114,10 @@ Return the appropriate apiVersion for ingress.
 {{- $version := include "concourse.kubeVersion" . -}}
 {{- if semverCompare "<1.14-0" $version -}}
 {{- print "extensions/v1beta1" -}}
-{{- else -}}
+{{- else if semverCompare "<1.20-0" $version -}}
 {{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
# Existing Issue

Fixes #204

# Why do we need this PR?
The ingress resource was moved to a new API group, with a full cutover starting in 1.22. Moved from `networking.k8s.io/v1beta1` to `networking.k8s.io/v1`.


# Changes proposed in this pull request
Based on [this comment](https://github.com/kubernetes/kubernetes/issues/94761#issuecomment-691982480) the new API group is only applied when the cluster version is >=1.20, which is when k8s starts reading from the stable api group instead of the beta api group for the ingress controller.

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [ ] ~Variables are documented in the `README.md`~
- [x] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
