### PR TITLE
Fix template for ingress API v1

### DIFF
--- a/templates/web-ingress.yaml
+++ b/templates/web-ingress.yaml
@@ -3,7 +3,8 @@
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := include "concourse.web.fullname" . -}}
 {{- $servicePort := .Values.concourse.web.bindPort -}}
-apiVersion: {{ template "concourse.ingress.apiVersion" . }}
+{{- $apiVersion := include "concourse.ingress.apiVersion" . -}}
+apiVersion: {{ $apiVersion }}
 kind: Ingress
 metadata:
   name: {{ template "concourse.web.fullname" . }}
@@ -22,9 +23,23 @@ spec:
     - host: {{ . }}
       http:
         paths:
+          {{- if or (eq $apiVersion "extensions/v1beta1") (eq $apiVersion "networking.k8s.io/v1beta1") }}
           - backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+          {{- else }}
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  {{- if typeIs "string" $servicePort }}
+                  name: {{ $servicePort }}
+                  {{- else }}
+                  number: {{ $servicePort }}
+                  {{- end }}
+          {{- end }}
     {{- end -}}
   {{- if .Values.web.ingress.tls }}
   tls:


### PR DESCRIPTION
This commit adjusts the ingress template to be compatible to
api-version networking.k8s.io/v1.

See also: #204

# Existing Issue

related to: #204 


# Why do we need this PR?

Deploying to a k8s > v1.20 is broken because of an incompatible ingress-spec.
`helm upgrade|install` throws following error:

```
Error: UPGRADE FAILED: error validating "": error validating data: [ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown field "serviceName" in io.k8s.api.networking.v1.IngressBackend, ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown field "servicePort" in io.k8s.api.networking.v1.IngressBackend]
helm.go:81: [debug] error validating "": error validating data: [ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown field "serviceName" in io.k8s.api.networking.v1.IngressBackend, ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown field "servicePort" in io.k8s.api.networking.v1.IngressBackend
```

# Changes proposed in this pull request

* `networking.k8s.io/v1` compatible ingress spec

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
