### PR TITLE
Remove bad volumes section from concourse.web.initContainers

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: concourse
 type: application
-version: 14.6.1
+version: 14.6.0
 appVersion: 7.0.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: concourse
 type: application
-version: 14.6.0
+version: 14.6.1
 appVersion: 7.0.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -63,20 +63,6 @@ spec:
             mountPath: {{ .Values.web.postgresqlSecretsPath | quote }}
             readOnly: true
         {{- end }}
-        volumes:
-        {{- if not (eq .Values.concourse.web.postgres.sslmode "disable") }}
-        - name: postgresql-keys
-          secret:
-            secretName: {{ template "concourse.web.fullname" . }}
-            defaultMode: 0400
-            items:
-              - key: postgresql-ca-cert
-                path: ca.cert
-              - key: postgresql-client-cert
-                path: client.cert
-              - key: postgresql-client-key
-                path: client.key
-        {{- end }}
       {{- if .Values.web.extraInitContainers }}
       {{- toYaml .Values.web.extraInitContainers | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
# Why do we need this PR?
<!--
No issue number? Please give us a few lines of context describing the need for this PR.
-->

Only one `volumes` entry is allowed for a pod spec, and it already
exists for the web deployment, and already has the same keys and values
as the newly introduced `volumes` section to the initContainer that
provides the migration work. 


# Changes proposed in this pull request
<!--
What are the changes included in this PR? Feel free to add as many lines as needed below.
-->

* This commit removes that section, which is invalid anyway, because `volumes` must exist at the `spec` level, not under `initContainers`.

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [x] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately



# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
