### PR TITLE
Add earlier paths option for web-ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.ingress.annotations` | Concourse Web Ingress annotations | `{}` |
 | `web.ingress.enabled` | Enable Concourse Web Ingress | `false` |
 | `web.ingress.hosts` | Concourse Web Ingress Hostnames | `[]` |
+| `web.ingress.rulesOverride` | Concourse Web Ingress rules (override) (alternate to `web.ingress.hosts`) | `[]` |
 | `web.ingress.tls` | Concourse Web Ingress TLS configuration | `[]` |
 | `web.keySecretsPath` | Specify the mount directory of the web keys secrets | `/concourse-keys` |
 | `web.labels`| Additional labels to be added to the worker pods | `{}` |
@@ -468,24 +469,29 @@ web:
     enabled: true
 
     ## Hostnames.
-    ## Must be provided if Ingress is enabled.
-    ## This is either a list of hostnames or a list of objects
-    ## containing both a name and any earlier paths for that
-    ## hostname.
-    ##
-    ## Example (no additional paths):
-    ##   - concourse.domain.com
-    ##
-    ## Example (additional earlier path):
-    ##   - name: concourse.domain.com
-    ##     additionalEarlierPaths:
-    ##     - path: '/*'
-    ##       backend:
-    ##         serviceName: "ssl-redirect"
-    ##         servicePort: "use-annotation"
+    ## Either `hosts` or `rulesOverride` must be provided if Ingress is enabled.
+    ## `hosts` sets up the Ingress with default rules per provided hostname.
     ##
     hosts:
       - concourse.domain.com
+
+    ## Ingress rules override
+    ## Either `hosts` or `rulesOverride` must be provided if Ingress is enabled.
+    ## `rulesOverride` allows the user to define the full set of ingress rules, for more complex Ingress setups.
+    ##
+    ##
+    rulesOverride:
+      - host: concourse.domain.com
+        http:
+          paths:
+            - path: '/*'
+              backend:
+                serviceName: "ssl-redirect"
+                servicePort: "use-annotation"
+            - path: '/*'
+              backend:
+                serviceName: "web-atc"
+                servicePort: 8080
 
     ## TLS configuration.
     ## Secrets must be manually created in the namespace.

--- a/README.md
+++ b/README.md
@@ -469,6 +469,20 @@ web:
 
     ## Hostnames.
     ## Must be provided if Ingress is enabled.
+    ## This is either a list of hostnames or a list of objects
+    ## containing both a name and any earlier paths for that
+    ## hostname.
+    ##
+    ## Example (no additional paths):
+    ##   - concourse.domain.com
+    ##
+    ## Example (additional earlier path):
+    ##   - name: concourse.domain.com
+    ##     additionalEarlierPaths:
+    ##     - path: '/*'
+    ##       backend:
+    ##         serviceName: "ssl-redirect"
+    ##         servicePort: "use-annotation"
     ##
     hosts:
       - concourse.domain.com

--- a/README.md
+++ b/README.md
@@ -490,8 +490,8 @@ web:
                 servicePort: "use-annotation"
             - path: '/*'
               backend:
-                serviceName: "web-atc"
-                servicePort: 8080
+                serviceName: "concourse-web"
+                servicePort: atc
 
     ## TLS configuration.
     ## Secrets must be manually created in the namespace.

--- a/templates/required-check.yaml
+++ b/templates/required-check.yaml
@@ -6,6 +6,7 @@
 {{- required "concourse.worker.tsa.hosts must be set in case of worker only deployment" "" }}
 {{ end }}
 
-{{ if and (.Values.web.ingress.enabled (not (or .Values.web.ingress.hosts .Values.web.ingress.rulesOverride))) }}
+{{ if and (.Values.web.ingress.enabled) (not (or .Values.web.ingress.hosts .Values.web.ingress.rulesOverride)) }}
+
 {{- required "When ingress is enabled, you must define either web.ingress.hosts or web.ingress.rulesOverride" "" }}
 {{ end }}

--- a/templates/required-check.yaml
+++ b/templates/required-check.yaml
@@ -5,3 +5,7 @@
 {{ if and (not .Values.concourse.worker.tsa.hosts) (and (not .Values.web.enabled) (.Values.worker.enabled)) }}
 {{- required "concourse.worker.tsa.hosts must be set in case of worker only deployment" "" }}
 {{ end }}
+
+{{ if and (.Values.web.ingress.enabled (not (or .Values.web.ingress.hosts .Values.web.ingress.rulesOverride))) }}
+{{- required "When ingress is enabled, you must define either web.ingress.hosts or web.ingress.rulesOverride" "" }}
+{{ end }}

--- a/templates/web-ingress.yaml
+++ b/templates/web-ingress.yaml
@@ -20,9 +20,12 @@ metadata:
 spec:
   rules:
     {{- range .Values.web.ingress.hosts }}
-    - host: {{ . }}
+    - host: {{ if .name }}{{ .name }}{{ else }}{{ . }}{{ end }}
       http:
         paths:
+          {{- if .additionalEarlierPaths }}
+          {{- toYaml .additionalEarlierPaths | nindent 10 }}
+          {{- end }}
           {{- if or (eq $apiVersion "extensions/v1beta1") (eq $apiVersion "networking.k8s.io/v1beta1") }}
           - backend:
               serviceName: {{ $serviceName }}

--- a/templates/web-ingress.yaml
+++ b/templates/web-ingress.yaml
@@ -19,13 +19,13 @@ metadata:
     {{- end }}
 spec:
   rules:
+    {{- if .Values.web.ingress.rulesOverride }}
+    {{- toYaml .Values.web.ingress.rulesOverride | nindent 4 }}
+    {{- else }}
     {{- range .Values.web.ingress.hosts }}
-    - host: {{ if .name }}{{ .name }}{{ else }}{{ . }}{{ end }}
+    - host: {{ . }}
       http:
         paths:
-          {{- if .additionalEarlierPaths }}
-          {{- toYaml .additionalEarlierPaths | nindent 10 }}
-          {{- end }}
           {{- if or (eq $apiVersion "extensions/v1beta1") (eq $apiVersion "networking.k8s.io/v1beta1") }}
           - backend:
               serviceName: {{ $serviceName }}
@@ -44,6 +44,7 @@ spec:
                   {{- end }}
           {{- end }}
     {{- end -}}
+    {{- end }}
   {{- if .Values.web.ingress.tls }}
   tls:
 {{ toYaml .Values.web.ingress.tls | indent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -2099,23 +2099,14 @@ web:
     annotations: {}
 
     ## Hostnames.
-    ## Must be provided if Ingress is enabled.
-    ## This is either a list of hostnames or a list of objects
-    ## containing both a name and any earlier paths for that
-    ## hostname.
-    ##
-    ## Example (no additional paths):
-    ##   - concourse.domain.com
-    ##
-    ## Example (additional earlier path):
-    ##   - name: concourse.domain.com
-    ##     additionalEarlierPaths:
-    ##     - path: '/*'
-    ##       backend:
-    ##         serviceName: "ssl-redirect"
-    ##         servicePort: "use-annotation"
-    ##
+    ## Either `hosts` or `rulesOverride` must be provided if Ingress is enabled.
+    ## `hosts` sets up the Ingress with default rules per provided hostname.
     hosts:
+
+    ## Ingress rules override
+    ## Either `hosts` or `rulesOverride` must be provided if Ingress is enabled.
+    ## `rulesOverride` allows the user to define the full set of ingress rules, for more complex Ingress setups.
+    rulesOverride:
 
     ## TLS configuration.
     ## Secrets must be manually created in the namespace.

--- a/values.yaml
+++ b/values.yaml
@@ -2100,8 +2100,20 @@ web:
 
     ## Hostnames.
     ## Must be provided if Ingress is enabled.
-    ## Example:
+    ## This is either a list of hostnames or a list of objects
+    ## containing both a name and any earlier paths for that
+    ## hostname.
+    ##
+    ## Example (no additional paths):
     ##   - concourse.domain.com
+    ##
+    ## Example (additional earlier path):
+    ##   - name: concourse.domain.com
+    ##     additionalEarlierPaths:
+    ##     - path: '/*'
+    ##       backend:
+    ##         serviceName: "ssl-redirect"
+    ##         servicePort: "use-annotation"
     ##
     hosts:
 


### PR DESCRIPTION
# Why do we need this PR?

Allows for adding additional, earlier paths to web-ingress. The impetus
for this change is to allow for setting up an HTTP -> HTTPS redirect
with AWS ALBs. For example:

```yaml
metadata:
  annotations:
    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type":"redirect","RedirectConfig":{"Protocol":"HTTPS","Port":"443","StatusCode":"HTTP_301"}}'
spec:
  rules:
  - host: "concourse.example.com"
    paths:
    - path: '/*'
      backend:
        serviceName: 'ssl-redirect'
        servicePort: 'use-annotation'
    - path: '/*'
      backend:
        serviceName: {{ template "web.fullname" . }}
        servicePort: "atc"
```

Reference: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.1/guide/tasks/ssl_redirect/

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [x] Variables are documented in the `README.md`
- [x] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
