### PR TITLE
fix: extra init container

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -48,21 +48,21 @@ spec:
       {{- end }}
       {{- end }}
       initContainers:
-      - name: concourse-migration
-        {{- if .Values.imageDigest }}
-        image: "{{ .Values.image }}@{{ .Values.imageDigest }}"
-        {{- else }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-        {{- end }}
-        args: ["migrate", "--migrate-to-latest-version"]
-        env:
+        - name: concourse-migration
+          {{- if .Values.imageDigest }}
+          image: "{{ .Values.image }}@{{ .Values.imageDigest }}"
+          {{- else }}
+          image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+          {{- end }}
+          args: ["migrate", "--migrate-to-latest-version"]
+          env:
 {{- include "concourse.postgresql.env" . | indent 10 }}
-        volumeMounts:
-        {{- if not (eq .Values.concourse.web.postgres.sslmode "disable") }}
-          - name: postgresql-keys
-            mountPath: {{ .Values.web.postgresqlSecretsPath | quote }}
-            readOnly: true
-        {{- end }}
+          volumeMounts:
+          {{- if not (eq .Values.concourse.web.postgres.sslmode "disable") }}
+            - name: postgresql-keys
+              mountPath: {{ .Values.web.postgresqlSecretsPath | quote }}
+              readOnly: true
+          {{- end }}
       {{- if .Values.web.extraInitContainers }}
       {{- toYaml .Values.web.extraInitContainers | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
# Why do we need this PR?
Fixes an issue when `extraInitContainers` flag is set. They were indented 8 chars which meant they fell under the `volumeMounts`
![image](https://user-images.githubusercontent.com/1285296/111292128-c6204f80-863f-11eb-9742-bd54facd83ce.png)


# Changes proposed in this pull request
* Extra indentation on the `migration` init container

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [ ] Variables are documented in the `README.md`
- [x] Which branch are you merging into?
    - `master`
# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
