### PR TITLE
fix: provide CONCOURSE_VAULT_AUTH_PARAM for ldap backend

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -546,7 +546,7 @@ spec:
             - name: CONCOURSE_VAULT_CLIENT_KEY
               value: "{{ .Values.web.vaultSecretsPath }}/client.key"
             {{- end }}
-            {{- if eq .Values.concourse.web.vault.authBackend "approle" }}
+            {{- if or (eq .Values.concourse.web.vault.authBackend "approle") (eq .Values.concourse.web.vault.authBackend "ldap") }}
             - name: CONCOURSE_VAULT_AUTH_PARAM
               valueFrom:
                 secretKeyRef:

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -546,7 +546,7 @@ spec:
             - name: CONCOURSE_VAULT_CLIENT_KEY
               value: "{{ .Values.web.vaultSecretsPath }}/client.key"
             {{- end }}
-            {{- if or (eq .Values.concourse.web.vault.authBackend "approle") (eq .Values.concourse.web.vault.authBackend "ldap") }}
+            {{- if .Values.concourse.web.vault.useAuthParam }}
             - name: CONCOURSE_VAULT_AUTH_PARAM
               valueFrom:
                 secretKeyRef:

--- a/values.yaml
+++ b/values.yaml
@@ -542,6 +542,11 @@ concourse:
       ##
       authBackend: ""
 
+      ## if the Vault authentication backend requires params from secrets, set this to true,
+      ## and provide a value in secrets (field `vault-client-auth-param`).
+      ##
+      useAuthParam: false
+
       ## Path to a directory of PEMEncoded CA cert files to verify the vault server SSL cert.
       ##
       caPath:
@@ -1994,7 +1999,7 @@ web:
       ## When using `web.service.api.type: ClusterIP`, sets the user-specified cluster IP.
       ## Example: 172.217.1.174
       ##
-      clusterIP: 
+      clusterIP:
 
       ## When using `web.service.api.type: LoadBalancer`, sets the user-specified load balancer IP.
       ## Example: 172.217.1.174


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to the Concourse Helm chart!
If you haven't already, please take a look at our [Code of Conduct](https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md).

To help us review your PR, please fill in the following information.
Feel free to delete any sections not applicable to your pull request.
-->

# Existing Issue
<!--
Is there an existing issue related to this PR? Fill in the issue number as follows: Fixes #1234.
-->

Fixes #222 

# Why do we need this PR?

Allow setting `CONCOURSE_VAULT_AUTH_PARAM` when using `CONCOURSE_VAULT_AUTH_BACKEND=ldap`

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [ ] Variables are documented in the `README.md`
- [ ] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
