### PR TITLE
allow deploy prometheus with different service type

### DIFF
--- a/templates/web-prometheus-svc.yaml
+++ b/templates/web-prometheus-svc.yaml
@@ -18,11 +18,26 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.web.service.prometheus.type }}
+  {{- if .Values.web.service.prometheus.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- range .Values.web.service.prometheus.loadBalancerSourceRanges }}
+    - {{ . }}
+    {{- end }}
+  {{- end }}
+  {{- if and (eq "ClusterIP" .Values.web.service.prometheus.type) .Values.web.service.prometheus.clusterIP }}
+  clusterIP: {{ .Values.web.service.prometheus.clusterIP }}
+  {{- end }}
+  {{- if and (eq "LoadBalancer" .Values.web.service.prometheus.type) .Values.web.service.prometheus.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.web.service.prometheus.loadBalancerIP }}
+  {{- end }}
   ports:
     - name: prometheus
       port: {{ .Values.concourse.web.prometheus.bindPort }}
       targetPort: prometheus
+      {{- if and (eq "NodePort" .Values.web.service.prometheus.type) .Values.web.service.prometheus.NodePort }}
+      nodePort: {{ .Values.web.service.prometheus.NodePort}}
+      {{- end }}
   selector:
     app: {{ template "concourse.web.fullname" . }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -1994,7 +1994,7 @@ web:
       ## When using `web.service.api.type: ClusterIP`, sets the user-specified cluster IP.
       ## Example: 172.217.1.174
       ##
-      clusterIP: 
+      clusterIP:
 
       ## When using `web.service.api.type: LoadBalancer`, sets the user-specified load balancer IP.
       ## Example: 172.217.1.174
@@ -2040,7 +2040,7 @@ web:
       ## When using `web.service.workerGateway.type: ClusterIP`, sets the user-specified cluster IP.
       ## Example: 172.217.1.174
       ##
-      clusterIP: None
+      clusterIP:
 
       ## When using `web.service.workerGateway.type: LoadBalancer`, sets the user-specified load balancer IP.
       ## Example: 172.217.1.174
@@ -2088,6 +2088,31 @@ web:
       ##
       ##
       annotations: {}
+
+      ## For minikube, set this to ClusterIP, elsewhere use LoadBalancer or NodePort
+      ## Ref: https://kubernetes.io/docs/user-guide/services/#publishing-services---service-types
+      ##
+      type: ClusterIP
+
+      ## When using `web.service.prometheus.type: ClusterIP`, sets the user-specified cluster IP.
+      ## Example: 172.217.1.174
+      ##
+      clusterIP:
+
+      ## When using `web.service.prometheus.type: LoadBalancer`, sets the user-specified load balancer IP.
+      ## Example: 172.217.1.174
+      ##
+      loadBalancerIP:
+
+      ## When using `web.service.prometheus.type: LoadBalancer`, restrict access to the load balancer to particular IPs
+      ## Example:
+      ##   - 192.168.1.10/32
+      ##
+      loadBalancerSourceRanges:
+
+      ## When using `web.service.prometheus.type: NodePort`, sets the nodePort
+      ##
+      NodePort:
 
   ## Ingress configuration.
   ## Ref: https://kubernetes.io/docs/user-guide/ingress/
@@ -2410,7 +2435,7 @@ postgresql:
   ## Allows for setting a specific cluster ip for the PostgreSQL
   ## service.
   service:
-    clusterIP: None
+    clusterIP:
 
   ## Persistent Volume Storage configuration for PostgreSQL.
   ##


### PR DESCRIPTION

Fixes #213  .


# Changes proposed in this pull request
Change prometheus service template to allow deployed as NodePort, ClusterIP or LoadBalancer service. 

remove "None" value for cluster IP in values.yml. refer to #163.
* 
* 
*

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [ ] Variables are documented in the `README.md`
- [ ] Which branch are you merging into?
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
