### PR TITLE
Fixing typo error on web-api-svc.yaml

### DIFF
--- a/templates/web-api-svc.yaml
+++ b/templates/web-api-svc.yaml
@@ -36,14 +36,14 @@ spec:
   - name: atc
     port: {{ .Values.concourse.web.bindPort }}
     targetPort: atc
-    {{- if and (eq "NodePort" .Values.web.service.api.type) .Values.web.service.api.atcNodePort }}
+    {{- if and (eq "NodePort" .Values.web.service.api.type) .Values.web.service.api.NodePort }}
     nodePort: {{ .Values.web.service.api.NodePort}}
     {{- end }}
 {{- if .Values.concourse.web.tls.enabled }}
   - name: atc-tls
     port: {{ .Values.concourse.web.tls.bindPort }}
     targetPort: atc-tls
-    {{- if and (eq "NodePort" .Values.web.service.api.type) .Values.web.service.api.atcTlsNodePort }}
+    {{- if and (eq "NodePort" .Values.web.service.api.type) .Values.web.service.api.tlsNodePort }}
     nodePort: {{ .Values.web.service.api.tlsNodePort}}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Changing atcNodePort to NodePort and atcTlsNodePort to tlsNodePort

Signed-off-by: Rui Yang <ryang@pivotal.io>
Co-authored-by: Esteban Foronda <eforonda@vmware.com>

# Existing Issue

Fixes #212 

# Changes proposed in this pull request
<!--
What are the changes included in this PR? Feel free to add as many lines as needed below.
-->

*  Fixing typos for atcTlsNodePort and atcNodePort for web-api-svc.yaml file

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [x ] Variables are documented in the `README.md`
- [x] Which branch are you merging into?
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
