### PR TITLE
Breaking: Bump postgres chart version to 10.3.13

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 9.2.0
-digest: sha256:5082c9ee31559622b64a7391ad9d2f8cf8488a0d34ff03fb1600dfac5f3d89e2
-generated: "2020-08-28T15:21:20.204476-04:00"
+  version: 10.3.13
+digest: sha256:0b35e861ab4e49a0d63eb83bf74a753a4b12d576d2d5f941701a659b4c93e1e4
+generated: "2021-03-26T10:09:32.189886-04:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ sources:
   - https://github.com/helm/charts
 dependencies:
   - name: postgresql
-    version: 9.2.0
+    version: 10.3.13
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
 maintainers:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -11,20 +11,14 @@ keywords:
   - concourse.ci
 home: https://concourse-ci.org/
 sources:
+  - https://github.com/concourse/concourse-chart
   - https://github.com/concourse/concourse
-  - https://github.com/helm/charts
 dependencies:
   - name: postgresql
     version: 10.3.13
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
 maintainers:
-  - name: cirocosta
-    email: cscosta@pivotal.io
-  - name: william-tran
-    email: will@autonomic.ai
-  - name: YoussB
-    email: byoussef@pivotal.io
-  - name: taylorsilva
-    email: tsilva@pivotal.io
+  - name: concourse-team
+    email: concourse@vmware.com
 engine: gotpl


### PR DESCRIPTION
# Why do we need this PR?
Breaking changes: https://github.com/bitnami/charts/tree/master/bitnami/postgresql#to-1000

tldr: uses helm api v2, same as our chart. Some name changes like
master -> primary, slave -> readReplicas

We should make this a major bump of the chart and link to the bitnami readme above

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [ ] Variables are documented in the `README.md`
- [x] Which branch are you merging into? **master**
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [x] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [x] Is the correct branch targeted? (`master` or `dev`)

