### PR TITLE
Don't set cluster ip if no value is specified

### DIFF
--- a/templates/web-api-svc.yaml
+++ b/templates/web-api-svc.yaml
@@ -27,7 +27,7 @@ spec:
     {{- end }}
   {{- end }}
   {{- if and (eq "ClusterIP" .Values.web.service.api.type) .Values.web.service.api.clusterIP }}
-  clusterIP: {{ .Values.web.service.api.clusterIP }}
+  {{ with .Values.web.service.api.clusterIP }}clusterIP: {{quote . }}{{ end}}
   {{- end }}
   {{- if and (eq "LoadBalancer" .Values.web.service.api.type) .Values.web.service.api.loadBalancerIP }}
   loadBalancerIP: {{ .Values.web.service.api.loadBalancerIP }}

--- a/templates/web-worker-gateway-svc.yaml
+++ b/templates/web-worker-gateway-svc.yaml
@@ -27,7 +27,7 @@ spec:
     {{- end }}
   {{- end }}
   {{- if and (eq "ClusterIP" .Values.web.service.workerGateway.type) .Values.web.service.workerGateway.clusterIP }}
-  clusterIP: {{ .Values.web.service.workerGateway.clusterIP }}
+  {{ with .Values.web.service.workerGateway.clusterIP }}clusterIP: {{quote . }}{{ end}}
   {{- end }}
   {{- if and (eq "LoadBalancer" .Values.web.service.workerGateway.type) .Values.web.service.workerGateway.loadBalancerIP }}
   loadBalancerIP: {{ .Values.web.service.workerGateway.loadBalancerIP }}

--- a/values.yaml
+++ b/values.yaml
@@ -2040,7 +2040,7 @@ web:
       ## When using `web.service.workerGateway.type: ClusterIP`, sets the user-specified cluster IP.
       ## Example: 172.217.1.174
       ##
-      clusterIP: None
+      clusterIP:
 
       ## When using `web.service.workerGateway.type: LoadBalancer`, sets the user-specified load balancer IP.
       ## Example: 172.217.1.174


### PR DESCRIPTION
fixes #187

I verified that when no value is set that `clusterIP` does not render. When a value is set it does render.

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [ ] Variables are documented in the `README.md`
- [ ] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
