### PR TITLE
Allow adding custom worker certs that all container can inherit

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `secrets.webTlsCaCert` | TLS CA certificate for the web component to terminate TLS connections | `nil` |
 | `secrets.workerKeyPub` | Concourse Worker Public Key | *See [values.yaml](values.yaml)* |
 | `secrets.workerKey` | Concourse Worker Private Key | *See [values.yaml](values.yaml)* |
+| `secrets.workerAdditionalCerts` | Concourse Worker Additional Certificates | *See [values.yaml](values.yaml)* |
 | `web.additionalAffinities` | Additional affinities to apply to web pods. E.g: node affinity | `{}` |
 | `web.additionalVolumeMounts` | VolumeMounts to be added to the web pods | `nil` |
 | `web.additionalVolumes` | Volumes to be added to the web pods | `nil` |
@@ -244,6 +245,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `worker.additionalAffinities` | Additional affinities to apply to worker pods. E.g: node affinity | `{}` |
 | `worker.additionalVolumeMounts` | VolumeMounts to be added to the worker pods | `nil` |
 | `worker.additionalVolumes` | Volumes to be added to the worker pods | `nil` |
+| `worker.additionalCertificates` | Enable adding additional certificates to worker certs pool | `false` |
 | `worker.annotations` | Annotations to be added to the worker pods | `{}` |
 | `worker.autoscaling` | Enable and configure pod autoscaling | `{}` |
 | `worker.cleanUpWorkDirOnStart` | Removes any previous state created in `concourse.worker.workDir` | `true` |
@@ -253,6 +255,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `worker.hardAntiAffinity` | Should the workers be forced (as opposed to preferred) to be on different nodes? | `false` |
 | `worker.hardAntiAffinityLabels` | Set of labels used for hard anti affinity rule | `{}` |
 | `worker.keySecretsPath` | Specify the mount directory of the worker keys secrets | `/concourse-keys` |
+| `worker.workerCertsPath` | Specify the path for additional worker certificates | `/etc/ssl/certs` |
 | `worker.kind` | Choose between `StatefulSet` to preserve state or `Deployment` for ephemeral workers | `StatefulSet` |
 | `worker.livenessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded | `5` |
 | `worker.livenessProbe.httpGet.path` | Path to access on the HTTP server when performing the healthcheck | `/` |

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `worker.hardAntiAffinity` | Should the workers be forced (as opposed to preferred) to be on different nodes? | `false` |
 | `worker.hardAntiAffinityLabels` | Set of labels used for hard anti affinity rule | `{}` |
 | `worker.keySecretsPath` | Specify the mount directory of the worker keys secrets | `/concourse-keys` |
-| `worker.CertsPath` | Specify the path for additional worker certificates | `/etc/ssl/certs` |
+| `worker.certsPath` | Specify the path for additional worker certificates | `/etc/ssl/certs` |
 | `worker.kind` | Choose between `StatefulSet` to preserve state or `Deployment` for ephemeral workers | `StatefulSet` |
 | `worker.livenessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded | `5` |
 | `worker.livenessProbe.httpGet.path` | Path to access on the HTTP server when performing the healthcheck | `/` |

--- a/README.md
+++ b/README.md
@@ -245,7 +245,6 @@ The following table lists the configurable parameters of the Concourse chart and
 | `worker.additionalAffinities` | Additional affinities to apply to worker pods. E.g: node affinity | `{}` |
 | `worker.additionalVolumeMounts` | VolumeMounts to be added to the worker pods | `nil` |
 | `worker.additionalVolumes` | Volumes to be added to the worker pods | `nil` |
-| `worker.additionalCertificates` | Enable adding additional certificates to worker certs pool | `false` |
 | `worker.annotations` | Annotations to be added to the worker pods | `{}` |
 | `worker.autoscaling` | Enable and configure pod autoscaling | `{}` |
 | `worker.cleanUpWorkDirOnStart` | Removes any previous state created in `concourse.worker.workDir` | `true` |
@@ -255,7 +254,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `worker.hardAntiAffinity` | Should the workers be forced (as opposed to preferred) to be on different nodes? | `false` |
 | `worker.hardAntiAffinityLabels` | Set of labels used for hard anti affinity rule | `{}` |
 | `worker.keySecretsPath` | Specify the mount directory of the worker keys secrets | `/concourse-keys` |
-| `worker.workerCertsPath` | Specify the path for additional worker certificates | `/etc/ssl/certs` |
+| `worker.CertsPath` | Specify the path for additional worker certificates | `/etc/ssl/certs` |
 | `worker.kind` | Choose between `StatefulSet` to preserve state or `Deployment` for ephemeral workers | `StatefulSet` |
 | `worker.livenessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded | `5` |
 | `worker.livenessProbe.httpGet.path` | Path to access on the HTTP server when performing the healthcheck | `/` |

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -98,7 +98,7 @@ spec:
             - name: pre-stop-hook
               mountPath: /pre-stop-hook.sh
               subPath: pre-stop-hook.sh
-            {{- if .Values.worker.additionalCertificates }}
+            {{- if and (not (kindIs "invalid" .Values.secrets.workerAdditionalCerts)) (.Values.secrets.workerAdditionalCerts | toString) }}
             - name: worker-certs
               mountPath: "{{ .Values.worker.workerCertsPath }}/worker-certs.pem"
               readOnly: true
@@ -149,15 +149,15 @@ spec:
                 path: host_key.pub
               - key: worker-key
                 path: worker_key
+        {{- if and (not (kindIs "invalid" .Values.secrets.workerAdditionalCerts)) (.Values.secrets.workerAdditionalCerts | toString) }}
         - name: worker-certs
           secret:
             secretName: {{ template "concourse.worker.fullname" . }}
             optional: true
             items:
-              {{- if .Values.worker.additionalCertificates }}
               - key: worker-certs
                 path: worker-certs.pem
-              {{- end }}
+        {{- end }}
       {{- if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion }}
   strategy:
 {{ toYaml .Values.worker.updateStrategy | indent 4 }}

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -98,6 +98,11 @@ spec:
             - name: pre-stop-hook
               mountPath: /pre-stop-hook.sh
               subPath: pre-stop-hook.sh
+            {{- if .Values.worker.additionalCertificates }}
+            - name: worker-certs
+              mountPath: "{{ .Values.worker.workerCertsPath }}/worker-certs.pem"
+              readOnly: true
+            {{- end }}
 
 {{- if .Values.worker.additionalVolumeMounts }}
 {{ toYaml .Values.worker.additionalVolumeMounts | indent 12 }}
@@ -144,6 +149,15 @@ spec:
                 path: host_key.pub
               - key: worker-key
                 path: worker_key
+        - name: worker-certs
+          secret:
+            secretName: {{ template "concourse.worker.fullname" . }}
+            optional: true
+            items:
+              {{- if .Values.worker.additionalCertificates }}
+              - key: worker-certs
+                path: worker-certs.pem
+              {{- end }}
       {{- if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion }}
   strategy:
 {{ toYaml .Values.worker.updateStrategy | indent 4 }}

--- a/templates/worker-secrets.yaml
+++ b/templates/worker-secrets.yaml
@@ -17,5 +17,8 @@ type: Opaque
 data:
   host-key-pub: {{ .Values.secrets.hostKeyPub | b64enc | quote }}
   worker-key: {{ .Values.secrets.workerKey | b64enc | quote }}
+  {{- if .Values.worker.additionalCertificates }}
+  worker-certs: {{ .Values.secrets.workerAdditionalCerts | b64enc | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/worker-statefulset.yaml
+++ b/templates/worker-statefulset.yaml
@@ -125,6 +125,11 @@ spec:
             - name: pre-stop-hook
               mountPath: /pre-stop-hook.sh
               subPath: pre-stop-hook.sh
+            {{- if .Values.worker.additionalCertificates }}
+            - name: worker-certs
+              mountPath: "{{ .Values.worker.workerCertsPath }}/worker-certs.pem"
+              readOnly: true
+            {{- end }}
 
 {{- if .Values.worker.additionalVolumeMounts }}
 {{ toYaml .Values.worker.additionalVolumeMounts | indent 12 }}
@@ -171,6 +176,15 @@ spec:
                 path: host_key.pub
               - key: worker-key
                 path: worker_key
+        - name: worker-certs
+          secret:
+            secretName: {{ template "concourse.worker.fullname" . }}
+            optional: true
+            items:
+              {{- if .Values.worker.additionalCertificates }}
+              - key: worker-certs
+                path: worker-certs.pem
+              {{- end }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/templates/worker-statefulset.yaml
+++ b/templates/worker-statefulset.yaml
@@ -125,7 +125,7 @@ spec:
             - name: pre-stop-hook
               mountPath: /pre-stop-hook.sh
               subPath: pre-stop-hook.sh
-            {{- if .Values.worker.additionalCertificates }}
+            {{- if and (not (kindIs "invalid" .Values.secrets.workerAdditionalCerts)) (.Values.secrets.workerAdditionalCerts | toString) }}
             - name: worker-certs
               mountPath: "{{ .Values.worker.workerCertsPath }}/worker-certs.pem"
               readOnly: true
@@ -176,15 +176,15 @@ spec:
                 path: host_key.pub
               - key: worker-key
                 path: worker_key
+        {{- if and (not (kindIs "invalid" .Values.secrets.workerAdditionalCerts)) (.Values.secrets.workerAdditionalCerts | toString) }}
         - name: worker-certs
           secret:
             secretName: {{ template "concourse.worker.fullname" . }}
             optional: true
             items:
-              {{- if .Values.worker.additionalCertificates }}
               - key: worker-certs
                 path: worker-certs.pem
-              {{- end }}
+        {{- end }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/values.yaml
+++ b/values.yaml
@@ -2247,6 +2247,11 @@ worker:
   ##
   keySecretsPath: "/concourse-keys"
 
+  ## For managing where additional certs should be added into worker
+  ## cert pool
+  ##
+  workerCertsPath: "/etc/ssl/certs"
+
   ## Configure additional volumeMounts for the
   ## worker container(s)
   ##
@@ -2255,6 +2260,12 @@ worker:
   ##     mountPath: /baggageclaim
   ##
   additionalVolumeMounts: []
+
+  ## Enable additional certificates to be added to
+  ## worker certificates pool where all containers
+  ## will inherit their certs from
+  ##
+  additionalCertificates: false
 
   ## Additional Labels to be added to the worker pods.
   ##
@@ -2682,6 +2693,18 @@ secrets:
   workerKeyPub: |-
     ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC496FSYFcBAKgDtMsBAJiF/6/NxlXKP5UZecyEsedYuTt1GOgJTwaA1qZ1LmHsbfLDE68oDdiM4uvxfI4wtLhz57w3u0jOUxZ2JeF7SVwEf1nVqLn4Gh/f8GUNQGSyIp1zUD5Bx9fq0PAyQ47mt7Ufi84rcf8LKl7nzAIHTcdg2BvTkQN9bUGPaq/Pb1W2bKPAQy4OzXTSIyrAJ89TH2jFeaZfyxQFGbD9jVHH/yl0oiMrDeaRYgccE5II+KY7WoLjsBry/9Qf2ERELKTK4UeIGIqWci9lab1ti+GxFPPiC3krNFjo4jShV4eUs4cNIrjwNrxVaKPXmU6o7Y3Hpayx Concourse
 
+  ## Concourse worker additional certificates
+  ## Example:
+  ## workerAdditionalCerts: |-
+  ##   -----BEGIN CERTIFICATE-----
+  ##   ....
+  ##   -----END CERTIFICATE-----
+  ##   -----BEGIN CERTIFICATE-----
+  ##   ....
+  ##   -----END CERTIFICATE-----
+  ##   ....
+  #
+  workerAdditionalCerts:
 
   ## Secrets for web interface login
   ##

--- a/values.yaml
+++ b/values.yaml
@@ -2247,10 +2247,10 @@ worker:
   ##
   keySecretsPath: "/concourse-keys"
 
-  ## For managing where additional certs should be added into worker
-  ## cert pool
+  ## For managing where additional certs should be added into a worker.
+  ## You can add additional certs with secrets.workerAdditionalCerts
   ##
-  workerCertsPath: "/etc/ssl/certs"
+  certsPath: "/etc/ssl/certs"
 
   ## Configure additional volumeMounts for the
   ## worker container(s)
@@ -2260,12 +2260,6 @@ worker:
   ##     mountPath: /baggageclaim
   ##
   additionalVolumeMounts: []
-
-  ## Enable additional certificates to be added to
-  ## worker certificates pool where all containers
-  ## will inherit their certs from
-  ##
-  additionalCertificates: false
 
   ## Additional Labels to be added to the worker pods.
   ##
@@ -2693,7 +2687,7 @@ secrets:
   workerKeyPub: |-
     ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC496FSYFcBAKgDtMsBAJiF/6/NxlXKP5UZecyEsedYuTt1GOgJTwaA1qZ1LmHsbfLDE68oDdiM4uvxfI4wtLhz57w3u0jOUxZ2JeF7SVwEf1nVqLn4Gh/f8GUNQGSyIp1zUD5Bx9fq0PAyQ47mt7Ufi84rcf8LKl7nzAIHTcdg2BvTkQN9bUGPaq/Pb1W2bKPAQy4OzXTSIyrAJ89TH2jFeaZfyxQFGbD9jVHH/yl0oiMrDeaRYgccE5II+KY7WoLjsBry/9Qf2ERELKTK4UeIGIqWci9lab1ti+GxFPPiC3krNFjo4jShV4eUs4cNIrjwNrxVaKPXmU6o7Y3Hpayx Concourse
 
-  ## Concourse worker additional certificates
+  ## Additonal certs to add to a workers certsPath
   ## Example:
   ## workerAdditionalCerts: |-
   ##   -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
# Existing Issue
Fixes #https://github.com/concourse/concourse-chart/issues/211.



# Changes proposed in this pull request
User will be able to config a .pem file that contains additional certs that could be added to worker certs pool by specifying a path (default to /etc/ssl/certs/worker-certs.pem). Notice the path has to be a file so it could be additional other than replacing entire /etc/ssl/certs directory.


# Contributor Checklist
- [ ] Variables are documented in the `README.md`
- [ ] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
