### PR TITLE
default `CONCOURSE_VAULT_AUTH_PARAM` to set if the corresponding secret is set

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -546,7 +546,8 @@ spec:
             - name: CONCOURSE_VAULT_CLIENT_KEY
               value: "{{ .Values.web.vaultSecretsPath }}/client.key"
             {{- end }}
-            {{- if .Values.concourse.web.vault.useAuthParam }}
+            {{- /* Enable the AUTH_PARAM by default when secrets.vaultAuthParam is set, unless useAuthParam is explicitly set to false */}}
+            {{- if and (or .Values.concourse.web.vault.useAuthParam .Values.secrets.vaultAuthParam) (ne .Values.concourse.web.vault.useAuthParam false) }}
             - name: CONCOURSE_VAULT_AUTH_PARAM
               valueFrom:
                 secretKeyRef:

--- a/values.yaml
+++ b/values.yaml
@@ -545,7 +545,7 @@ concourse:
       ## if the Vault authentication backend requires params from secrets, set this to true,
       ## and provide a value in secrets (field `vault-client-auth-param`).
       ##
-      useAuthParam: false
+      useAuthParam:
 
       ## Path to a directory of PEMEncoded CA cert files to verify the vault server SSL cert.
       ##


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to the Concourse Helm chart!
If you haven't already, please take a look at our [Code of Conduct](https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md).

To help us review your PR, please fill in the following information.
Feel free to delete any sections not applicable to your pull request.
-->

# Why do we need this PR?
<!--
No issue number? Please give us a few lines of context describing the need for this PR.
-->

#223 introduced a breaking change - before, when the vault backend was set to approle, we'd set `CONCOURSE_VAULT_AUTH_PARAM`.  now, it's only set if `useAuthParam` is explicitly set to true, since it defaults to false. this means that upgrading from 15.0.x -> 15.1.x unset that param, unless you knew to enable `useAuthParam` (which wasn't documented in the release notes).

it seems more sane to set the auth param if either you explicitly opt-in (by enabling `useAuthParam`) OR if you set the vault auth param in the secret, and didn't explicitly opt-out by setting `useAuthParam` to false

# Changes proposed in this pull request
<!--
What are the changes included in this PR? Feel free to add as many lines as needed below.
-->

* No default for `.Values.concourse.web.vault.useAuthParam` - distinguish between unset and `false`
* Set `CONCOURSE_VAULT_AUTH_PARAM` from secret if `Values.concourse.web.vault.useAuthParam` is set to true or if `.Values.secrets.vaultAuthParam` is set
  * Note: we still want `useAuthParam`, since the secret may be created external to helm, and we still need some way of indicating we want that secret

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [ ] Variables are documented in the `README.md`
- [ ] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
