### PR TITLE
Use the default baggageclaim driver set in the concourse binary

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -1725,7 +1725,7 @@ concourse:
       ## Driver to use for managing volumes.
       ## Possible values: detect, naive, btrfs, and overlay.
       ##
-      driver: naive
+      driver:
 
       ## Path to btrfs binary
       ##


### PR DESCRIPTION
which is detect and will use overlay most likely. naive is really slow
once you have large files involved.

# Why do we need this PR?
We should use the defaults in the binary instead of setting our own in the chart.

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [x] Variables are documented in the `README.md`
- [x] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
