### PR TITLE
Add flag to allow host access on containerd

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `worker.containerd.maxContainers` | Max container capacity where 0 means no limit | `nil` |
 | `worker.containerd.networkPool` | Network range to use for dynamically allocated container subnets | `nil` |
 | `worker.containerd.requestTimeout` | Time to wait for requests to Containerd to complete | `nil` |
+| `worker.containerd.allowHostAccess` | Allows containers to reach host network | `false` |
 
 For configurable Concourse parameters, refer to [`values.yaml`](values.yaml)' `concourse` section. All parameters under this section are strictly mapped from the `concourse` binary commands.
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -284,6 +284,10 @@ Return concourse environment variables for worker configuration
   value: {{ . | title | quote }}
 {{- end }}
 {{- end }}
+{{- if .Values.concourse.worker.containerd.allowHostAccess }}
+- name: CONCOURSE_CONTAINERD_ALLOW_HOST_ACCESS
+  value: {{ .Values.concourse.worker.containerd.allowHostAccess | quote }}
+{{- end }}
 {{- if .Values.concourse.worker.containerd.maxContainers }}
 - name: CONCOURSE_CONTAINERD_MAX_CONTAINERS
   value: {{ .Values.concourse.worker.containerd.maxContainers | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -1649,7 +1649,7 @@ concourse:
       ## Path to a config file to use for the Containerd daemon.
       config:
 
-      ## Enable a proxy DNS server for Garden
+      ## Enable a proxy DNS server for Garden. Note: this implicitly turns on container access to host network.
       dnsProxyEnable:
 
       ## MTU size for container network interfaces. Defaults to the MTU of the interface used for outbound access by the host
@@ -1671,6 +1671,9 @@ concourse:
       ##   - 1.1.1.1
       ##   - 2.2.2.2
       restrictedNetworks: []
+
+      ## Allows containers to reach host network.
+      allowHostAccess:
 
       ## Maximum container capacity. 0 means no limit. Defaults to 250.
       maxContainers:


### PR DESCRIPTION
add the `CONCOURSE_CONTAINERD_ALLOW_HOST_ACCESS` flag to chart.

<!--
Hi there! Thanks for submitting a pull request to the Concourse Helm chart!
If you haven't already, please take a look at our [Code of Conduct](https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md).

To help us review your PR, please fill in the following information.
Feel free to delete any sections not applicable to your pull request.
-->

# Existing Issue
<!--
Is there an existing issue related to this PR? Fill in the issue number as follows: Fixes #1234.
-->

part of: concourse/concourse#6720

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [x] Variables are documented in the `README.md`
- [x] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
