### PR TITLE
allow configuring priorityClassName for pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.service.prometheus.annotations` | Concourse Web Prometheus Service annotations | `nil` |
 | `web.service.prometheus.labels` | Additional concourse web prometheus service labels | `nil` |
 | `web.shareProcessNamespace` | Enable or disable the process namespace sharing for the web nodes | `false` |
+| `web.priorityClassName` | Sets a PriorityClass for the web pods | `nil` |
 | `web.sidecarContainers` | Array of extra containers to run alongside the Concourse web container | `nil` |
 | `web.extraInitContainers` | Array of extra init containers to run before the Concourse web container | `nil` |
 | `web.strategy` | Strategy for updates to deployment. | `{}` |
@@ -273,6 +274,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `worker.resources.requests.memory` | Minimum amount of memory resources requested | `512Mi` |
 | `worker.sidecarContainers` | Array of extra containers to run alongside the Concourse worker container | `nil` |
 | `worker.extraInitContainers` | Array of extra init containers to run before the Concourse worker container | `nil` |
+| `worker.priorityClassName` | Sets a PriorityClass for the worker pods | `nil` |
 | `worker.terminationGracePeriodSeconds` | Upper bound for graceful shutdown to allow the worker to drain its tasks | `60` |
 | `worker.tolerations` | Tolerations for the worker nodes | `[]` |
 | `worker.updateStrategy` | `OnDelete` or `RollingUpdate` (requires Kubernetes >= 1.7) | `RollingUpdate` |

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -66,6 +66,9 @@ spec:
       {{- if .Values.web.extraInitContainers }}
       {{- toYaml .Values.web.extraInitContainers | nindent 8 }}
       {{- end }}
+      {{- if .Values.web.priorityClassName }}
+      priorityClassName: {{ .Values.web.priorityClassName }}
+      {{- end }}
       {{- if .Values.web.shareProcessNamespace }}
       shareProcessNamespace: true
       {{- end }}

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -43,6 +43,9 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if .Values.worker.priorityClassName }}
+      priorityClassName: {{ .Values.worker.priorityClassName }}
+      {{- end }}
       {{- if .Values.worker.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}
       {{- end }}

--- a/templates/worker-statefulset.yaml
+++ b/templates/worker-statefulset.yaml
@@ -45,6 +45,9 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if .Values.worker.priorityClassName }}
+      priorityClassName: {{ .Values.worker.priorityClassName }}
+      {{- end }}
       {{- if .Values.worker.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}
       {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -1837,6 +1837,10 @@ web:
   ##
   extraInitContainers: []
 
+  ## Pod priority class to assign to web pods.
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
+  priorityClassName:
+
   ## Enable or disable the process namespace sharing for the web nodes.
   ## This allows signaling the concourse process from a sidecar container.
   ## eg.: signal concourse web to reload the team authorized keys file.
@@ -2358,6 +2362,10 @@ worker:
   ##     effect: "NoSchedule"
   ##
   tolerations: []
+
+  ## Pod priority class to assign to worker pods.
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
+  priorityClassName:
 
   ## Time to allow the pod to terminate before being forcefully terminated. This should provide time for
   ## the worker to retire, i.e. drain its tasks. See https://concourse-ci.org/worker-internals.html for worker


### PR DESCRIPTION
# Changes proposed in this pull request

this add new (optional) `web.priorityClassName` and `worker.priorityClassName` values for configuring the PodPriority of the web/worker pods.

See: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority

# Why do we need this PR?

when attempting to run concourse workers that consume a large percentage of a node's resources you can come up against scheduling issues due to poor bin-packing of pods on to nodes.

setting pod priorities can be useful in this case, allowing the scheduler shuffle things around and evict pods to make room.

# Contributor Checklist

- [x] Variables are documented in the `README.md`
- [x] Which branch are you merging into? -> `master`

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
