### PR TITLE
Fix broken .Values.concourse.worker.garden.dnsProxyEnable helper

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -236,7 +236,7 @@ Return concourse environment variables for worker configuration
 - name: CONCOURSE_GARDEN_CONFIG
   value: {{ .Values.concourse.worker.garden.config | quote }}
 {{- end }}
-{{- if .Values.concourse.worker.garden.dnsProxyEnable }}
+{{- if not (kindIs "invalid" .Values.concourse.worker.garden.dnsProxyEnable) }}
 - name: CONCOURSE_GARDEN_DNS_PROXY_ENABLE
   value: {{ .Values.concourse.worker.garden.dnsProxyEnable | quote }}
 {{- end }}


### PR DESCRIPTION
The helm chart check for concourse.worker.garden.dnsProxyEnable assumes the default value of this variable is false.  However, the underlying env var CONCOURSE_GARDEN_DNS_PROXY_ENABLE defaults to true in the container.

In short, changing this value to false has no effect on the worker deployment, and setting to true sets an env var to true that is already default true (in the Dockerfile), so again, no effect.

# Changes proposed in this pull request
* Change the boolean check in the helper to `not(kindIs "invalid")` which passes when the value has any actual value (true or false)