### PR TITLE
support datadog agent uds filepath

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -679,16 +679,23 @@ spec:
               value: {{ .Values.concourse.web.metrics.attribute | quote }}
             {{- end }}
             {{- if .Values.concourse.web.datadog.enabled }}
-            - name: CONCOURSE_DATADOG_AGENT_HOST
             {{- if .Values.concourse.web.datadog.agentHostUseHostIP }}
+            - name: CONCOURSE_DATADOG_AGENT_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
-            {{- else }}
+            {{- else if .Values.concourse.web.datadog.agentHost }}
+            - name: CONCOURSE_DATADOG_AGENT_HOST
               value: {{ .Values.concourse.web.datadog.agentHost | quote }}
             {{- end }}
+            {{- if .Values.concourse.web.datadog.agentPort }}
             - name: CONCOURSE_DATADOG_AGENT_PORT
               value: {{ .Values.concourse.web.datadog.agentPort | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.datadog.agentUdsFilepath }}
+            - name: CONCOURSE_DATADOG_AGENT_UDS_FILEPATH
+              value: {{ .Values.concourse.web.datadog.agentUdsFilepath | quote }}
+            {{- end }}
             {{- if .Values.concourse.web.datadog.prefix }}
             - name: CONCOURSE_DATADOG_PREFIX
               value: {{ .Values.concourse.web.datadog.prefix | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -728,6 +728,11 @@ concourse:
       ##
       agentPort: 8125
 
+      ## Datadog agent unix domain socket (uds) filepath to expose dogstatsd metrics
+      ## e.g. /tmp/datadog.socket
+      ##
+      agentUdsFilepath:
+
       ## Prefix for all metrics to easily find them in Datadog
       ##
       prefix: "concourse.ci"


### PR DESCRIPTION
Port over commit to add datadog agent uds filepath field to release/7.4.x branch

Fixes https://ci.concourse-ci.org/teams/main/pipelines/release/jobs/k8s-check-helm-params/builds/3?vars.version=%227.4.x%22

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [ ] Variables are documented in the `README.md`
- [ ] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
