### PR TITLE
Add volume/volume mount for sending datadog metrics over uds

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.datadog.agentHostUseHostIP` | Use IP of Pod's node overrides `agentHost` | `false` |
 | `web.datadog.agentHost` | Datadog Agent host | `127.0.0.1` |
 | `web.datadog.agentPort` | Datadog Agent port | `8125` |
+| `web.datadog.agentUdsFilepath` | Datadog agent unix domain socket (uds) filepath to expose dogstatsd metrics (ex. `/tmp/datadog.socket`) | `nil` |
 | `web.datadog.enabled` | Enable or disable Datadog metrics | `false` |
 | `web.datadog.prefix` | Prefix for emitted metrics | `"concourse.ci"` |
 | `web.enabled` | Enable or disable the web component | `true` |

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -1474,6 +1474,11 @@ spec:
               mountPath: {{ .Values.web.syslogSecretsPath | quote }}
               readOnly: true
             {{- end }}
+            {{- if .Values.concourse.web.datadog.agentUdsFilepath }}
+            - name: dsdsocket
+              mountPath: {{ .Values.concourse.web.datadog.agentUdsFilepath | dir | quote }}
+              readOnly: true
+            {{- end }}
             - name: auth-keys
               mountPath: {{ .Values.web.authSecretsPath | quote }}
               readOnly: true
@@ -1592,6 +1597,11 @@ spec:
             items:
               - key: syslog-ca-cert
                 path: ca.cert
+        {{- end }}
+        {{- if .Values.concourse.web.datadog.agentUdsFilepath }}
+        - name: dsdsocket
+          hostPath:
+            path: {{ .Values.concourse.web.datadog.agentUdsFilepath | dir | printf "%s/"| quote }}
         {{- end }}
         - name: auth-keys
           secret:


### PR DESCRIPTION
Add volume/volume mount for sending datadog dogstatsd metrics over unix domain socket (uds) when user sets a value for `agentUdsFilepath`.

Signed-off-by: Jennifer Hwang <jmhwang7@gmail.com>

# Why do we need this PR?
<!--
No issue number? Please give us a few lines of context describing the need for this PR.
-->
This matches setup instructions by Datadog here: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/?tab=kubernetes#using-origin-detection-for-container-tagging

# Changes proposed in this pull request
<!--
What are the changes included in this PR? Feel free to add as many lines as needed below.
-->

* Adds read-only volumeMount for the socket
* Adds hostPath volume for the socket
* Adds readme docs for `web.datadog.agentUdsFilepath`

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [x] Variables are documented in the `README.md`
- [x] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
