### PR TITLE
Add HPA autoscaling behavior field

### DIFF
--- a/templates/worker-horizontal-pod-autoscaler.yaml
+++ b/templates/worker-horizontal-pod-autoscaler.yaml
@@ -12,6 +12,10 @@ metadata:
 spec:
   minReplicas: {{ .Values.concourse.worker.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.concourse.worker.autoscaling.maxReplicas }}
+  {{- if .Values.concourse.worker.autoscaling.behavior }}
+  behavior:
+{{ toYaml .Values.concourse.worker.autoscaling.behavior | indent 4 }}
+  {{- end }}
   metrics:
     {{- if .Values.concourse.worker.autoscaling.builtInMetrics }}
 {{ toYaml .Values.concourse.worker.autoscaling.builtInMetrics | indent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -1894,6 +1894,16 @@ concourse:
       # for this to work you need to configure the metric eg. with prometheus adapter
 #      maxReplicas: 1
 #      minReplicas: 1
+#     behavior:
+#        scaleDown:
+#          stabilizationWindowSeconds: 1200
+#          selectPolicy: Min
+#          policies:
+#          - type: Percent
+#            value: 10
+#            periodSeconds: 300
+#        scaleUp:
+#          stabilizationWindowSeconds: 60
 #      builtInMetrics:
 #        - type: Resource
 #          resource:

--- a/values.yaml
+++ b/values.yaml
@@ -1894,14 +1894,14 @@ concourse:
       # for this to work you need to configure the metric eg. with prometheus adapter
 #      maxReplicas: 1
 #      minReplicas: 1
-#     behavior:
+#      behavior:
 #        scaleDown:
 #          stabilizationWindowSeconds: 1200
-#          selectPolicy: Min
-#          policies:
-#          - type: Percent
-#            value: 10
-#            periodSeconds: 300
+#            selectPolicy: Min
+#            policies:
+#              - type: Percent
+#                value: 10
+#                periodSeconds: 300
 #        scaleUp:
 #          stabilizationWindowSeconds: 60
 #      builtInMetrics:


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to the Concourse Helm chart!
If you haven't already, please take a look at our [Code of Conduct](https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md).

To help us review your PR, please fill in the following information.
Feel free to delete any sections not applicable to your pull request.
-->

# Why do we need this PR?
This PR adds the behavior field to the worker HPA template.  Once added the behavior field will allow users to adjust scale down and scale up windows beyond the default kubernetes settings.

https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#default-behavior


# Changes proposed in this pull request
<!--
What are the changes included in this PR? Feel free to add as many lines as needed below.
-->

* Add spec.behavior field to worker HPA to allow for custom scale behavior

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [ ] Variables are documented in the `README.md`
- [ ] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
