### PR TITLE
add hostedDomains to oidc auth values config

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -1461,6 +1461,13 @@ concourse:
         ##
         userNameKey: username
 
+        ## Comma separated list of whitelisted domains when using Google
+        ## If this field is nonempty, only users from a listed domain will be allowed to log in
+        ## For example,
+        ## hostedDomains: domain.com,domain2.com,domain3.com
+        ##
+        hostedDomains:
+
         ## Disable OIDC groups claim fetching
         ##
         disableGroups:


### PR DESCRIPTION
Add the key to values.yml with example value string. Not sure why it was missing in the first place.