### PR TITLE
remove jaeger config default values

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -1828,7 +1828,7 @@ concourse:
       #
       ## Example: "worker"
       ##
-      serviceName: worker-trace
+      serviceName:
 
       ## Attributes to attach to traces as metadata.
       #
@@ -1841,7 +1841,7 @@ concourse:
       #
       ## Example: "http://jaeger:14268/api/traces"
       ##
-      jaegerEndpoint: http://somethinig/api/traces
+      jaegerEndpoint:
 
       ## Tags to include to components
       ##
@@ -1853,7 +1853,7 @@ concourse:
       ##
       ## Example: "worker"
       ##
-      jaegerService: worker-trace-jaeger
+      jaegerService:
 
       ## GCP's Project ID
       ##


### PR DESCRIPTION

Fixes #279  .


# Changes proposed in this pull request
Remove those example values that causes extra log messages. So it will be same config as they are in `concourse.web.tracing`. 
