### PR TITLE
Ignore replicas number in Deployment/Statefulset when using autoscaling

### DIFF
--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -10,7 +10,9 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  {{- if not .Values.concourse.worker.autoscaling.maxReplicas }}
   replicas: {{ .Values.worker.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "concourse.worker.fullname" . }}

--- a/templates/worker-statefulset.yaml
+++ b/templates/worker-statefulset.yaml
@@ -11,7 +11,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   serviceName: {{ template "concourse.worker.fullname" . }}
+  {{- if not .Values.concourse.worker.autoscaling.maxReplicas }}
   replicas: {{ .Values.worker.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "concourse.worker.fullname" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -1915,11 +1915,11 @@ concourse:
 #      behavior:
 #        scaleDown:
 #          stabilizationWindowSeconds: 1200
-#            selectPolicy: Min
-#            policies:
-#              - type: Percent
-#                value: 10
-#                periodSeconds: 300
+#          selectPolicy: Min
+#          policies:
+#            - type: Percent
+#              value: 10
+#              periodSeconds: 300
 #        scaleUp:
 #          stabilizationWindowSeconds: 60
 #      builtInMetrics:


### PR DESCRIPTION
Using replicas and HPA at same time can causes some troubles when reapplying some resources since it reset to replicas number.

Fixes # .
Make `replicas` conditional on using HPA for workers


# Changes proposed in this pull request
* Added condition to replicas in worker deployment
* Added condition to replicas in worker statefulset
* Fix some indentation issue in example vars

