### PR TITLE
Bump concourse version to 7.7.1

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: concourse
 type: application
-version: 16.1.21
-appVersion: 7.7.0
+version: 16.1.22
+appVersion: 7.7.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479
 keywords:


### PR DESCRIPTION
# Existing Issue
It is not an issue with the chart. We just need a new Concourse version with bug fixes.
# Fixes
Concourse `7.7.0` (the latest version provided by this chart) has [this terrible pipeline archiving bug](https://github.com/concourse/concourse/issues/8167). We need a version that fixes that bug, and that version is `7.7.1`.

# Changes proposed in this pull request
* Bump chart version to `16.1.22` (from `16.1.21`)
* Bump concourse version to `7.7.1`

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [x] Variables are documented in the `README.md`
- [x] Which branch are you merging into?
    `master`


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
