### PR TITLE
Update web values for resource type check interval

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -388,6 +388,10 @@ spec:
             - name: CONCOURSE_RESOURCE_WITH_WEBHOOK_CHECKING_INTERVAL
               value: {{ .Values.concourse.web.resourceWithWebhookCheckingInterval | quote }}
             {{- end }}
+             {{- if .Values.concourse.web.resourceTypeCheckingInterval }}
+            - name: CONCOURSE_RESOURCE_TYPE_CHECKING_INTERVAL
+              value: {{ .Values.concourse.web.resourceTypeCheckingInterval | quote }}
+            {{- end }}
             {{- if .Values.concourse.web.baseResourceTypeDefaults }}
             - name: CONCOURSE_BASE_RESOURCE_TYPE_DEFAULTS
               value: /brt-defaults.yml

--- a/values.yaml
+++ b/values.yaml
@@ -303,6 +303,10 @@ concourse:
     ##
     resourceWithWebhookCheckingInterval: 1m
 
+    ## Interval on which to check for new versions of any resource types 
+    ##
+    resourceTypeCheckingInterval: 1m
+
     ## Configuration file for specifying defaults for base resource types
     ## Ref: https://concourse-ci.org/concourse-web.html#resource-defaults
     ## Example:


### PR DESCRIPTION
# Existing Issue

There is an issue [here](https://github.com/concourse/concourse/issues/8264) & a PR [here](https://github.com/concourse/concourse/pull/8381) to update the web config, therefore the helm chart needs updated too.

# Why do we need this PR?

Explained above.


# Changes proposed in this pull request

* Adds ability to configure a resource type checking interval at a global level like currently exists for resources/prototypes/resource types & resources with webhooks.  This PR splits the resource type interval out from the current global catch all check interval.


# Contributor Checklist

- [x] Variables are documented in the `README.md`
- [x] Which branch are you merging into?
    - `master` 

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
