### PR TITLE
Add the complete list of supported options for postgres.sslmode

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -453,7 +453,7 @@ concourse:
       ##
       socket:
 
-      ## Whether or not to use SSL.
+      ## Whether or not to use SSL (currently supporting disbale, require, verify-ca, verify-full).
       ##
       sslmode: disable
 

--- a/values.yaml
+++ b/values.yaml
@@ -453,7 +453,7 @@ concourse:
       ##
       socket:
 
-      ## Whether or not to use SSL (currently supporting disbale, require, verify-ca, verify-full).
+      ## Whether or not to use SSL (currently supporting disable, require, verify-ca, verify-full).
       ##
       sslmode: disable
 


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to the Concourse Helm chart!
If you haven't already, please take a look at our [Code of Conduct](https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md).

To help us review your PR, please fill in the following information.
Feel free to delete any sections not applicable to your pull request.
-->

# Existing Issue


# Why do we need this PR?
It's unclear which value needs to be set to enable SSL encryption for the postgres database connection. The most reasonable value - 'enable' - does not exist and the Concourse [source code](https://github.com/concourse/flag/blob/2be0b225f9229c7b9d184724e83c1841f942f5fb/postgres_config.go#L21) needs to be read to understand the available choices.

# Changes proposed in this pull request

*  Add the complete list of supported options for `concourse.web.postgres.sslmode`

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [ ] Variables are documented in the `README.md`
- [ ] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
