### PR TITLE
bump postgresql chart as old version not exists

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ sources:
   - https://github.com/helm/charts
 dependencies:
   - name: postgresql
-    version: 10.3.13
+    version: 10.16.2
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
 maintainers:


### PR DESCRIPTION
```
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://charts.bitnami.com/bitnami" chart repository
Error: can't get a valid version for repositories postgresql. Try changing the version constraint in Chart.yaml
```
When running release pipeline for concourse 6.7.x, above error shows up in [k8s-smoke job](https://ci.concourse-ci.org/teams/main/pipelines/release/jobs/k8s-smoke/builds/1?vars.version=%226.7.x%22). Old version of postgresql chart does not exist anymore on binami postgresql chart repo.