### PR TITLE
remove oidc.hostedDomains

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -1308,10 +1308,6 @@ spec:
             - name: CONCOURSE_OIDC_GROUPS_KEY
               value: {{ .Values.concourse.web.auth.oidc.groupsKey | quote}}
             {{- end }}
-            {{- if .Values.concourse.web.auth.oidc.hostedDomains }}
-            - name: CONCOURSE_OIDC_HOSTED_DOMAINS
-              value: {{ .Values.concourse.web.auth.oidc.hostedDomains | quote }}
-            {{- end }}
             {{- if .Values.concourse.web.auth.oidc.useCaCert }}
             - name: CONCOURSE_OIDC_CA_CERT
               value: "{{ .Values.web.authSecretsPath }}/oidc_ca.cert"

--- a/values.yaml
+++ b/values.yaml
@@ -1500,13 +1500,6 @@ concourse:
         ##
         userNameKey: username
 
-        ## Comma separated list of whitelisted domains when using Google
-        ## If this field is nonempty, only users from a listed domain will be allowed to log in
-        ## For example,
-        ## hostedDomains: domain.com,domain2.com,domain3.com
-        ##
-        hostedDomains:
-
         ## Disable OIDC groups claim fetching
         ##
         disableGroups:


### PR DESCRIPTION
the actual Dex configure has never worked

and it is now [removed](https://github.com/concourse/dex/commit/67d9142887361d1cc2ea125f59f0f244449742a7) from concourse/dex
