### PR TITLE
Fix postgreSQL persistence chart-values

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -2629,7 +2629,7 @@ persistence:
     #     app-volume: "concourse"
 
 ## Configuration values for the postgresql dependency.
-## Ref: https://artifacthub.io/packages/helm/bitnami/postgresql/11.6.3
+## Ref: https://artifacthub.io/packages/helm/bitnami/postgresql/11.9.8
 ##
 postgresql:
 
@@ -2667,34 +2667,39 @@ postgresql:
   service:
     clusterIP:
 
-  ## Persistent Volume Storage configuration for PostgreSQL.
+  ## Configuration for the primary database of the PostgreSQL subchart,
+  ## i.e. the instance used by the web component.
   ##
-  ## Ref: https://kubernetes.io/docs/user-guide/persistent-volumes
-  ##
-  persistence:
-    ## Enable PostgreSQL persistence using Persistent Volume Claims.
-    ##
-    enabled: true
+  primary:
 
-    ## Persistent Volume Storage Class to be used by PersistentVolumes created
-    ## for PostgreSQL.
+    ## Persistent Volume Storage configuration for PostgreSQL.
     ##
-    ## If defined, storageClassName: <storageClass>
-    ## If set to "-", storageClassName: "", which disables dynamic provisioning
-    ## If undefined (the default) or set to null, no storageClassName spec is
-    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-    ##   GKE, AWS & OpenStack)
+    ## Ref: https://kubernetes.io/docs/user-guide/persistent-volumes
     ##
-    storageClass:
+    persistence:
+      ## Enable PostgreSQL persistence using Persistent Volume Claims.
+      ##
+      enabled: true
 
-    ## Persistent Volume Access Mode.
-    ##
-    accessModes:
-      - ReadWriteOnce
+      ## Persistent Volume Storage Class to be used by PersistentVolumes created
+      ## for PostgreSQL.
+      ##
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If undefined (the default) or set to null, no storageClassName spec is
+      ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+      ##   GKE, AWS & OpenStack)
+      ##
+      storageClass:
 
-    ## Persistent Volume Storage Size.
-    ##
-    size: 8Gi
+      ## Persistent Volume Access Mode.
+      ##
+      accessModes:
+        - ReadWriteOnce
+
+      ## Persistent Volume Storage Size.
+      ##
+      size: 8Gi
 
 ## For Kubernetes RBAC support:
 ##


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to the Concourse Helm chart!
If you haven't already, please take a look at our [Code of Conduct](https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md).

To help us review your PR, please fill in the following information.
Feel free to delete any sections not applicable to your pull request.
-->

# Why do we need this PR?
Currently some of the values intended to be used by the PostgreSQL-subchart do not have the correct structure. The subchart, as it is currently used, expects them at `(.values).primary.persistence` (checked both the in-use version `11.9.8` and the current version `12.1.9`) but they are passed along simply at `(.values).persistence`. The relevant part of the PostgreSQL chart documentation can be found at https://artifacthub.io/packages/helm/bitnami/postgresql#postgresql-primary-parameters.


# Changes proposed in this pull request
<!--
What are the changes included in this PR? Feel free to add as many lines as needed below.
-->

*  Move the value `postgresql.persistence` to `postgresql.primary.persistence`

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [x] Variables are documented in the `README.md`
- [x] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
