### PR TITLE
remove not used oidc --hosted-domains flag

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -1308,10 +1308,6 @@ spec:
             - name: CONCOURSE_OIDC_GROUPS_KEY
               value: {{ .Values.concourse.web.auth.oidc.groupsKey | quote}}
             {{- end }}
-            {{- if .Values.concourse.web.auth.oidc.hostedDomains }}
-            - name: CONCOURSE_OIDC_HOSTED_DOMAINS
-              value: {{ .Values.concourse.web.auth.oidc.hostedDomains | quote }}
-            {{- end }}
             {{- if .Values.concourse.web.auth.oidc.useCaCert }}
             - name: CONCOURSE_OIDC_CA_CERT
               value: "{{ .Values.web.authSecretsPath }}/oidc_ca.cert"

--- a/values.yaml
+++ b/values.yaml
@@ -1500,13 +1500,6 @@ concourse:
         ##
         userNameKey: username
 
-        ## Comma separated list of whitelisted domains when using Google
-        ## If this field is nonempty, only users from a listed domain will be allowed to log in
-        ## For example,
-        ## hostedDomains: domain.com,domain2.com,domain3.com
-        ##
-        hostedDomains:
-
         ## Disable OIDC groups claim fetching
         ##
         disableGroups:


### PR DESCRIPTION
odic.hostedDomains is not used in Dex code base and it got cleaned up in latest Dex release. So we need to update Concourse code base accordingly.