### PR TITLE
Add labels to worker volumeClaimTemplate

### DIFF
--- a/.github/workflows/nightly-merge.yml
+++ b/.github/workflows/nightly-merge.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Merge master into dev
-      uses: robotology/gh-action-nightly-merge@v1.2.0
+      uses: robotology/gh-action-nightly-merge@v1.4.0
       with:
         stable_branch: 'master'
         development_branch: 'dev'

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: concourse
 type: application
-version: 17.0.37
-appVersion: 7.8.3
+version: 17.1.0
+appVersion: 7.9.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479
 keywords:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `imageDigest` | Specific image digest to use in place of a tag. | `nil` |
 | `imagePullPolicy` | Concourse image pull policy | `IfNotPresent` |
 | `imagePullSecrets` | Array of imagePullSecrets in the namespace for pulling images | `[]` |
-| `imageTag` | Concourse image version | `7.8.3` |
+| `imageTag` | Concourse image version | `7.9.0` |
 | `image` | Concourse image | `concourse/concourse` |
 | `nameOverride` | Provide a name in place of `concourse` for `app:` labels | `nil` |
 | `persistence.enabled` | Enable Concourse persistence using Persistent Volume Claims | `true` |

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `persistence.worker.accessMode` | Concourse Worker Persistent Volume Access Mode | `ReadWriteOnce` |
 | `persistence.worker.size` | Concourse Worker Persistent Volume Storage Size | `20Gi` |
 | `persistence.worker.storageClass` | Concourse Worker Persistent Volume Storage Class | `generic` |
+| `persistence.worker.labels` | Concourse Worker Persistent Volume Labels | `{}` |
 | `postgresql.enabled` | Enable PostgreSQL as a chart dependency | `true` |
 | `postgresql.persistence.accessModes` | Persistent Volume Access Mode | `["ReadWriteOnce"]` |
 | `postgresql.persistence.enabled` | Enable PostgreSQL persistence using Persistent Volume Claims | `true` |

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -1308,10 +1308,6 @@ spec:
             - name: CONCOURSE_OIDC_GROUPS_KEY
               value: {{ .Values.concourse.web.auth.oidc.groupsKey | quote}}
             {{- end }}
-            {{- if .Values.concourse.web.auth.oidc.hostedDomains }}
-            - name: CONCOURSE_OIDC_HOSTED_DOMAINS
-              value: {{ .Values.concourse.web.auth.oidc.hostedDomains | quote }}
-            {{- end }}
             {{- if .Values.concourse.web.auth.oidc.useCaCert }}
             - name: CONCOURSE_OIDC_CA_CERT
               value: "{{ .Values.web.authSecretsPath }}/oidc_ca.cert"

--- a/templates/worker-statefulset.yaml
+++ b/templates/worker-statefulset.yaml
@@ -195,6 +195,12 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: concourse-work-dir
+      {{- if .Values.persistence.worker.labels }}
+        labels: 
+      {{- with .Values.persistence.worker.labels }}
+{{ toYaml . | trim | indent 10 }}
+      {{- end }}        
+      {{- end }}        
       spec:
       {{- if .Values.persistence.worker.selector }}
         selector: {{- .Values.persistence.worker.selector | toYaml | nindent 10 }}

--- a/values.yaml
+++ b/values.yaml
@@ -2629,9 +2629,7 @@ persistence:
     #     app-volume: "concourse"
 
     # Add labels to worker volumeClaimTemplate
-    labels: 
-      test: yesyes
-      really: nono
+    labels: {}
 
 ## Configuration values for the postgresql dependency.
 ## Ref: https://artifacthub.io/packages/helm/bitnami/postgresql/11.6.3

--- a/values.yaml
+++ b/values.yaml
@@ -21,7 +21,7 @@ image: concourse/concourse
 ##      of `concourse/concourse`.
 ## Ref: https://hub.docker.com/r/concourse/concourse/tags/
 ##
-imageTag: "7.8.3"
+imageTag: "7.9.0"
 
 ## Specific image digest to use in place of a tag.
 ## Ref: https://kubernetes.io/docs/concepts/configuration/overview/#container-images
@@ -1499,13 +1499,6 @@ concourse:
         ## Concourse user name.
         ##
         userNameKey: username
-
-        ## Comma separated list of whitelisted domains when using Google
-        ## If this field is nonempty, only users from a listed domain will be allowed to log in
-        ## For example,
-        ## hostedDomains: domain.com,domain2.com,domain3.com
-        ##
-        hostedDomains:
 
         ## Disable OIDC groups claim fetching
         ##

--- a/values.yaml
+++ b/values.yaml
@@ -2628,6 +2628,11 @@ persistence:
     #   matchLabels:
     #     app-volume: "concourse"
 
+    # Add labels to worker volumeClaimTemplate
+    labels: 
+      test: yesyes
+      really: nono
+
 ## Configuration values for the postgresql dependency.
 ## Ref: https://artifacthub.io/packages/helm/bitnami/postgresql/11.6.3
 ##


### PR DESCRIPTION
# Why do we need this PR?

This PR adds support for applying labels to the PVCs created by the worker's statefulset, via volumeClaimTemplates. In some backup regimes, items are included / excluded from backups by virtue of their labels.

In my particular case, I don't want Velero to attempt to backup the workers' PVCs, so I need to add the `velero.io/exclude-from-backup=true` label to all the worker PVCs.


# Changes proposed in this pull request
<!--
What are the changes included in this PR? Feel free to add as many lines as needed below.
-->

*  Add a new chart value, `persistence.worker.labels`

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [x] Variables are documented in the `README.md`
- [x] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
