### PR TITLE
add worker containerd config

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -304,6 +304,14 @@ Return concourse environment variables for worker configuration
 - name: CONCOURSE_CONTAINERD_INIT_BIN
   value: {{ .Values.concourse.worker.containerd.initBin | quote }}
 {{- end }}
+{{- if .Values.concourse.worker.containerd.ociHooksDir }}
+- name: CONCOURSE_CONTAINERD_OCI_HOOKS_DIR
+  value: {{ .Values.concourse.worker.containerd.ociHooksDir | quote }}
+{{- end }}
+{{- if .Values.concourse.worker.containerd.seccompProfile }}
+- name: CONCOURSE_CONTAINERD_SECCOMP_PROFILE
+  value: {{ .Values.concourse.worker.containerd.seccompProfile | quote }}
+{{- end }}
 {{- if .Values.concourse.worker.containerd.cniPluginsDir }}
 - name: CONCOURSE_CONTAINERD_CNI_PLUGINS_DIR
   value: {{ .Values.concourse.worker.containerd.cniPluginsDir | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -1792,6 +1792,12 @@ concourse:
       ## Path to a dumb init executable, defaults to /usr/local/concourse/bin/init
       initBin:
 
+      ## Path to the oci hooks dir, defaults to none
+      ociHooksDir:
+
+      ## Path to a seccomp filter override, defaults to a restrictive default set
+      seccompProfile:
+
       ## Path to CNI network plugins, defaults to /usr/local/concourse/bin
       cniPluginsDir:
 


### PR DESCRIPTION
for oci-hooks-dir and seccomp-profile

refer to https://github.com/concourse/concourse/pull/8044

