### PR TITLE
Enable Port Name overrides on web-api-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.service.api.loadBalancerSourceRanges` | Concourse Web API Service Load Balancer Source IP ranges | `nil` |
 | `web.service.api.tlsNodePort` | Sets the nodePort for api tls when using `NodePort` | `nil` |
 | `web.service.api.type` | Concourse Web API service type | `ClusterIP` |
+| `web.service.api.port.name` | Sets the port name for web service with `targetPort` `atc` | `atc` |
+| `web.service.api.tlsPort.name` | Sets the port name for web service with `targetPort` `atc-tls` | `atc-tls` |
 | `web.service.workerGateway.annotations` | Concourse Web workerGateway Service annotations | `nil` |
 | `web.service.workerGateway.labels` | Additional concourse web workerGateway service labels | `nil` |
 | `web.service.workerGateway.loadBalancerIP` | The IP to use when web.service.workerGateway.type is LoadBalancer | `nil` |

--- a/templates/web-api-svc.yaml
+++ b/templates/web-api-svc.yaml
@@ -33,14 +33,14 @@ spec:
   loadBalancerIP: {{ .Values.web.service.api.loadBalancerIP }}
   {{- end }}
   ports:
-  - name: atc
+  - name: ({ .Values.concourse.web.service.atc.port.name }}
     port: {{ .Values.concourse.web.bindPort }}
     targetPort: atc
     {{- if and (eq "NodePort" .Values.web.service.api.type) .Values.web.service.api.NodePort }}
     nodePort: {{ .Values.web.service.api.NodePort}}
     {{- end }}
 {{- if .Values.concourse.web.tls.enabled }}
-  - name: atc-tls
+  - name: ({ .Values.concourse.web.service.atc-tls.port.name }}
     port: {{ .Values.concourse.web.tls.bindPort }}
     targetPort: atc-tls
     {{- if and (eq "NodePort" .Values.web.service.api.type) .Values.web.service.api.tlsNodePort }}

--- a/templates/web-api-svc.yaml
+++ b/templates/web-api-svc.yaml
@@ -33,14 +33,14 @@ spec:
   loadBalancerIP: {{ .Values.web.service.api.loadBalancerIP }}
   {{- end }}
   ports:
-  - name: ({ .Values.concourse.web.service.atc.port.name }}
+  - name: ({ .Values.concourse.web.service.api.port.name }}
     port: {{ .Values.concourse.web.bindPort }}
     targetPort: atc
     {{- if and (eq "NodePort" .Values.web.service.api.type) .Values.web.service.api.NodePort }}
     nodePort: {{ .Values.web.service.api.NodePort}}
     {{- end }}
 {{- if .Values.concourse.web.tls.enabled }}
-  - name: ({ .Values.concourse.web.service.atc-tls.port.name }}
+  - name: {{ .Values.concourse.web.service.api.tlsPort.name }}
     port: {{ .Values.concourse.web.tls.bindPort }}
     targetPort: atc-tls
     {{- if and (eq "NodePort" .Values.web.service.api.type) .Values.web.service.api.tlsNodePort }}

--- a/values.yaml
+++ b/values.yaml
@@ -2239,6 +2239,14 @@ web:
       ##
       tlsNodePort:
 
+      ## When using thirdy party service mesh providers such as istio, port name ovverrides can be set to meet the default `http` naming convention
+      ##
+      port:
+        name: atc
+      
+      tlsPort:
+        name: atc-tls
+      
     workerGateway:
       ## For minikube, set this to ClusterIP, elsewhere use LoadBalancer or NodePort
       ## Ref: https://kubernetes.io/docs/user-guide/services/#publishing-services---service-types


### PR DESCRIPTION
When deploying this chart with Istio ingress due to istio's convention which requires port names  to be prefixed `http-` this subsequently results in needing to patch web-api-svc manifest post deployment.

# Changes proposed in this pull request

This allows users to override the default names provided which eases the issues when using istio service mesh

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [x] Variables are documented in the `README.md`
- [ ] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
