### PR TITLE
Decoupling init-rm initContainer and extra initContainers

### DIFF
--- a/templates/worker-statefulset.yaml
+++ b/templates/worker-statefulset.yaml
@@ -53,11 +53,13 @@ spec:
       {{- if .Values.worker.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- if .Values.worker.cleanUpWorkDirOnStart }}
+      {{- if or .Values.worker.cleanUpWorkDirOnStart .Values.worker.extraInitContainers }}
       initContainers:
+      {{- end }}
       {{- if .Values.worker.extraInitContainers }}
       {{- toYaml .Values.worker.extraInitContainers | nindent 8 }}
       {{- end }}
+      {{- if .Values.worker.cleanUpWorkDirOnStart }}
         - name: {{ template "concourse.worker.fullname" . }}-init-rm
           {{- if .Values.imageDigest }}
           image: "{{ .Values.image }}@{{ .Values.imageDigest }}"


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to the Concourse Helm chart!
If you haven't already, please take a look at our [Code of Conduct](https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md).

To help us review your PR, please fill in the following information.
Feel free to delete any sections not applicable to your pull request.
-->

# Why do we need this PR?
<!--
No issue number? Please give us a few lines of context describing the need for this PR.
-->
Decouples the extraInitContainers and cleanUpWorkDirOnStart variables. Currently it is impossible to have an extraInitContainer without also having the init-rm container


# Changes proposed in this pull request
<!--
What are the changes included in this PR? Feel free to add as many lines as needed below.
-->
Slightly changed conditionality around the initContainers in the statefulset yaml

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [x] Variables are documented in the `README.md`
- [x] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))

merging into **master**

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
