### PR TITLE
Add securityContext to concourse-web initContainer

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: concourse
 type: application
-version: 17.1.0
+version: 17.2.0
 appVersion: 7.9.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -58,6 +58,10 @@ spec:
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
           {{- end }}
           args: ["migrate", "--migrate-to-latest-version"]
+          {{- if .Values.web.securityContext }}
+          securityContext:
+          {{- toYaml .Values.web.securityContext | nindent 12 }}
+          {{- end }}          
           env:
 {{- include "concourse.postgresql.env" . | indent 12 }}
           volumeMounts:


### PR DESCRIPTION
Signed-off-by: David Young <davidy@funkypenguin.co.nz>

<!--
Hi there! Thanks for submitting a pull request to the Concourse Helm chart!
If you haven't already, please take a look at our [Code of Conduct](https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md).

To help us review your PR, please fill in the following information.
Feel free to delete any sections not applicable to your pull request.
-->

# Existing Issue
<!--
Is there an existing issue related to this PR? Fill in the issue number as follows: Fixes #1234.
-->

Fixes # .

# Why do we need this PR?

In the concourse-web pod, the primary container supports a user-configurable securityContext. However, the "migration" initContainer does not, which causes automated security assessement tools (in my case, Fairwinds Polaris) to fail the entire pod.


# Changes proposed in this pull request

This PR simply adds the same securityContext used for the concourse-web primary containier, to the migration initContainer

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [X] Variables are documented in the `README.md`
- [X] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
