### PR TITLE
feat: support labels on worker volumeClaimTemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `persistence.worker.accessMode` | Concourse Worker Persistent Volume Access Mode | `ReadWriteOnce` |
 | `persistence.worker.size` | Concourse Worker Persistent Volume Storage Size | `20Gi` |
 | `persistence.worker.storageClass` | Concourse Worker Persistent Volume Storage Class | `generic` |
+| `persistence.worker.labels` | Concourse Worker Persistent Volume Labels | `{}` |
 | `postgresql.enabled` | Enable PostgreSQL as a chart dependency | `true` |
 | `postgresql.persistence.accessModes` | Persistent Volume Access Mode | `["ReadWriteOnce"]` |
 | `postgresql.persistence.enabled` | Enable PostgreSQL persistence using Persistent Volume Claims | `true` |

--- a/templates/worker-statefulset.yaml
+++ b/templates/worker-statefulset.yaml
@@ -195,6 +195,12 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: concourse-work-dir
+      {{- if .Values.persistence.worker.labels }}
+        labels:
+      {{- with .Values.persistence.worker.labels }}
+{{ toYaml . | trim | indent 10 }}
+      {{- end }}
+      {{- end }}
       spec:
       {{- if .Values.persistence.worker.selector }}
         selector: {{- .Values.persistence.worker.selector | toYaml | nindent 10 }}

--- a/values.yaml
+++ b/values.yaml
@@ -2634,6 +2634,9 @@ persistence:
     #   matchLabels:
     #     app-volume: "concourse"
 
+    # Add labels to worker volumeClaimTemplate
+    labels: {}
+
 ## Configuration values for the postgresql dependency.
 ## Ref: https://artifacthub.io/packages/helm/bitnami/postgresql/11.9.8
 ##


### PR DESCRIPTION
# Existing Issue

> This PR adds support for applying labels to the PVCs created by the worker's statefulset, via volumeClaimTemplates. In some backup regimes, items are included/excluded from backups by virtue of their labels.

Closes & replaces: https://github.com/concourse/concourse-chart/pull/322.

# Why do we need this PR?
<!--
No issue number? Please give us a few lines of context describing the need for this PR.
-->

# Changes proposed in this pull request

* Add a new chart value, `persistence.worker.labels`

# Contributor Checklist
- [x] Variables are documented in the `README.md`
- [x] Which branch are you merging into? **master**

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
