### PR TITLE
Add support for deploymentAnnotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.ingress.tls` | Concourse Web Ingress TLS configuration | `[]` |
 | `web.keySecretsPath` | Specify the mount directory of the web keys secrets | `/concourse-keys` |
 | `web.labels`| Additional labels to be added to the web deployment `metadata.labels` | `{}` |
+| `web.deploymentAnnotations` | Additional annotations to be added to the web deployment `metadata.annotations` | `{}` |
 | `web.livenessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded | `5` |
 | `web.livenessProbe.httpGet.path` | Path to access on the HTTP server when performing the healthcheck | `/api/v1/info` |
 | `web.livenessProbe.httpGet.port` | Name or number of the port to access on the container | `atc` |
@@ -261,6 +262,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `worker.hardAntiAffinity` | Should the workers be forced (as opposed to preferred) to be on different nodes? | `false` |
 | `worker.hardAntiAffinityLabels` | Set of labels used for hard anti affinity rule | `{}` |
 | `worker.keySecretsPath` | Specify the mount directory of the worker keys secrets | `/concourse-keys` |
+| `worker.deploymentAnnotations` | Additional annotations to be added to the worker deployment `metadata.annotations` | `{}` |
 | `worker.certsPath` | Specify the path for additional worker certificates | `/etc/ssl/certs` |
 | `worker.kind` | Choose between `StatefulSet` to preserve state or `Deployment` for ephemeral workers | `StatefulSet` |
 | `worker.livenessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded | `5` |

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -3,6 +3,10 @@ apiVersion: {{ template "concourse.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "concourse.web.fullname" . }}
+  {{- if .Values.web.deploymentAnnotations }}
+  annotations:
+{{ toYaml .Values.web.deploymentAnnotations | indent 4 }}
+  {{- end }}
   labels:
     app: {{ template "concourse.web.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -4,6 +4,10 @@ apiVersion: {{ template "concourse.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "concourse.worker.fullname" . }}
+  {{- if .Values.worker.deploymentAnnotations }}
+  annotations:
+{{ toYaml .Values.worker.deploymentAnnotations | indent 4 }}
+  {{- end }}
   labels:
     app: {{ template "concourse.worker.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/values.yaml
+++ b/values.yaml
@@ -2146,6 +2146,17 @@ web:
   ##
   labels: {}
 
+  ## Additional Annotations to be added to the web deployment
+  ## Per Kubernetes spec, the values of each annotation must be a string.
+  ##
+  ## Example:
+  ##   key1: "value1"
+  ##   key2: "value2"
+  ##
+  ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  deploymentAnnotations: {}
+
   ## Additional Labels to be added to the web pods.
   ##
   ## Example:
@@ -2473,6 +2484,17 @@ worker:
   ##     mountPath: /baggageclaim
   ##
   additionalVolumeMounts: []
+
+  ## Additional Annotations to be added to the web deployment
+  ## Per Kubernetes spec, the values of each annotation must be a string.
+  ##
+  ## Example:
+  ##   key1: "value1"
+  ##   key2: "value2"
+  ##
+  ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  deploymentAnnotations: {}
 
   ## Additional Labels to be added to the worker pods.
   ##


### PR DESCRIPTION
Allow user to optionally configure annotations on the worker and web Deployments via Chart values. This could be used (for my example) with integrations for ImageStreams in OKD/OpenShift.

---

# Why do we need this PR?

While Annotations generally have a wide variety of uses, I found the need for this feature while working with [OKD/OpenShift's ImageStreams](https://docs.openshift.com/container-platform/4.13/openshift_images/image-streams-manage.html). ImageStreams will modify Deployments according to a user's configuration (via Deployment Annotations) to use specific digests or even the built-in registry.

# Changes proposed in this pull request

* Allow users to specify Annotations to the Web/Worker Deployments via the new `deploymentAnnotations` field under `web` and `worker` respectively.

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [X] Variables are documented in the `README.md`
- [X] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
