### PR TITLE
Update autoscaling API version

### DIFF
--- a/templates/worker-horizontal-pod-autoscaler.yaml
+++ b/templates/worker-horizontal-pod-autoscaler.yaml
@@ -1,6 +1,10 @@
 {{- if  .Values.concourse.worker.autoscaling }}
   {{- if .Values.concourse.worker.autoscaling.maxReplicas }}
+{{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: autoscaling/v2
+{{- else -}}
 apiVersion: autoscaling/v2beta2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "concourse.worker.fullname" . }}
@@ -29,4 +33,3 @@ spec:
     name: {{ template "concourse.worker.fullname" . }}
   {{- end }}
 {{- end }}
-


### PR DESCRIPTION
# Why do we need this PR?
<!--
No issue number? Please give us a few lines of context describing the need for this PR.
-->
The `autoscaling/v2beta2` API is deprecated in v1.23+, unavailable in v1.26+

# Changes proposed in this pull request
<!--
What are the changes included in this PR? Feel free to add as many lines as needed below.
-->

* Use `autoscaling/v2` if Kubernetes version is >= 1.23

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [x] Variables are documented in the `README.md`
- [x] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
