### PR TITLE
feat: support adding additional ports to workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.vaultSecretsPath` | Specify the mount directory of the web vault secrets | `/concourse-vault` |
 | `worker.additionalAffinities` | Additional affinities to apply to worker pods. E.g: node affinity | `{}` |
 | `worker.additionalVolumeMounts` | VolumeMounts to be added to the worker pods | `nil` |
+| `worker.additionalPorts` | Additional ports to be added to worker pods | `[]` |
 | `worker.additionalVolumes` | Volumes to be added to the worker pods | `nil` |
 | `worker.annotations` | Annotations to be added to the worker pods | `{}` |
 | `worker.autoscaling` | Enable and configure pod autoscaling | `{}` |

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -94,6 +94,9 @@ spec:
           ports:
             - name: worker-hc
               containerPort: {{ .Values.concourse.worker.healthcheckBindPort }}
+{{- if .Values.worker.additionalPorts }}
+{{ toYaml .Values.worker.additionalPorts | indent 12 }}
+{{- end }}
 {{- if .Values.worker.resources }}
           resources:
 {{ toYaml .Values.worker.resources | indent 12 }}

--- a/templates/worker-statefulset.yaml
+++ b/templates/worker-statefulset.yaml
@@ -117,6 +117,9 @@ spec:
           ports:
             - name: worker-hc
               containerPort: {{ .Values.concourse.worker.healthcheckBindPort }}
+{{- if .Values.worker.additionalPorts }}
+{{ toYaml .Values.worker.additionalPorts | indent 12 }}
+{{- end }}
 {{- if .Values.worker.resources }}
           resources:
 {{ toYaml .Values.worker.resources | indent 12 }}

--- a/values.yaml
+++ b/values.yaml
@@ -2501,6 +2501,16 @@ worker:
   ##     mountPath: /baggageclaim
   ##
   additionalVolumeMounts: []
+  
+  ## Additional ports to be added to worker pods
+  ## Example:
+  ##   - containerPort: 7788
+  ##     name: worker-bc
+  ##     protocol: TCP
+  ##
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/
+  ##
+  additionalPorts: []
 
   ## Additional Annotations to be added to the web deployment
   ## Per Kubernetes spec, the values of each annotation must be a string.


### PR DESCRIPTION


# Existing Issue
- https://github.com/concourse/concourse-chart/issues/267 (This is directly related, but no changes resulted from the issue)


# Why do we need this PR?
We we were looking to implement p2p streaming for workers; however, there was no support for adding additional ports for worker communication. 


# Changes proposed in this pull request
- adds ability to add additional ports to worker pods

# Contributor Checklist
- [x] Variables are documented in the `README.md`
- [x] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
