### PR TITLE
fix: Change the "userIDFieldPerConnector" parameter's place

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The following table lists the configurable parameters of the Concourse chart and
 
 | Parameter               | Description                           | Default                                                    |
 | ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
+| `concourse.web.auth.userIDFieldPerConnector` | Define how to display user ID for each authentication connector. | `nil` |
 | `fullnameOverride` | Provide a name to substitute for the full names of resources | `nil` |
 | `imageDigest` | Specific image digest to use in place of a tag. | `nil` |
 | `imagePullPolicy` | Concourse image pull policy | `IfNotPresent` |

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ The following table lists the configurable parameters of the Concourse chart and
 
 | Parameter               | Description                           | Default                                                    |
 | ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
-| `concourse.web.auth.userIDFieldPerConnector` | Define how to display user ID for each authentication connector. | `nil` |
 | `fullnameOverride` | Provide a name to substitute for the full names of resources | `nil` |
 | `imageDigest` | Specific image digest to use in place of a tag. | `nil` |
 | `imagePullPolicy` | Concourse image pull policy | `IfNotPresent` |

--- a/values.yaml
+++ b/values.yaml
@@ -1070,6 +1070,13 @@ concourse:
       ## Either "local" or "ldap". Defaults to "local".
       passwordConnector:
 
+      # Define how to display user ID for each authentication connector.
+      # Format is <connector>:<fieldname>. Valid field names are user_id,
+      # name, username and email, where name maps to claims field username,
+      # and username maps to claims field preferred username.
+      #
+      userIDFieldPerConnector: ""
+
       mainTeam:
 
         ## Configuration file for specifying the main teams params.
@@ -1091,13 +1098,6 @@ concourse:
         ## that the users were added (`secrets.localUsers`).
         ##
         localUser: "test"
-
-        # Define how to display user ID for each authentication connector.
-        # Format is <connector>:<fieldname>. Valid field names are user_id,
-        # name, username and email, where name maps to claims field username,
-        # and username maps to claims field preferred username.
-        #
-        userIDFieldPerConnector: ""
 
         ## Authentication (Main Team) (CloudFoundry)
         ##


### PR DESCRIPTION


<!--
Hi there! Thanks for submitting a pull request to the Concourse Helm chart!
If you haven't already, please take a look at our [Code of Conduct](https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md).

To help us review your PR, please fill in the following information.
Feel free to delete any sections not applicable to your pull request.
-->

# Why do we need this PR?
The `concourse-chart/templates/web-deployment.yaml` file is looking for `Values.concourse.web.auth.userIDFieldPerConnector` but the parameter is in `concourse.web.auth.mainTeam.userIDFieldPerConnector`, according to the documentation.


# Changes proposed in this pull request
* Change the parameter `userIDFieldPerConnector` to the correct place, which is `concourse.web.auth.userIDFieldPerConnector` instead of `concourse.web.auth.mainTeam.userIDFieldPerConnector` (or the opposite, if that's what is decided. But in that case it shouldn't go to the `master` branch).

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [x] Variables are documented in the `README.md`
- [x] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
