### PR TITLE
resend shutdownSignal to keep the state:retiring

### DIFF
--- a/templates/worker-prestop-configmap.yaml
+++ b/templates/worker-prestop-configmap.yaml
@@ -10,6 +10,12 @@ metadata:
 data:
   pre-stop-hook.sh: |
     #!/bin/bash
-    kill -s {{ .Values.concourse.worker.shutdownSignal }} 1
-    while [ -e /proc/1 ]; do sleep 1; done
-
+    while true; do
+      kill -s {{ .Values.concourse.worker.shutdownSignal }} 1
+      for i in {0..60}; do
+        sleep 1
+        if ! [ -e /proc/1 ]; then
+          exit 0
+        fi
+      done
+    done


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to the Concourse Helm chart!
If you haven't already, please take a look at our [Code of Conduct](https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md).

To help us review your PR, please fill in the following information.
Feel free to delete any sections not applicable to your pull request.
-->

# Existing Issue
no

# Why do we need this PR?
In our productive k8s clusters we observed following problem:
During eviction of the Worker Pod the pre-stop-hook.sh was triggered as expected.
With `fly -t infra workers` we could verify, that the worker state changed to "retiring".
But suddenly, the state changed back to `running`, for whatever reason.
Thus, the worker, even if it was in pod state `terminating` accepted new incoming concourse jobs.
And the worker was running until the pod.spec.terminationGracePeriodSeconds were reached.

# Changes proposed in this pull request

*  With this PR, the pre-stop-hook easily sends the shutdownSignal again and again, assuring that the state remain `retiring`.

# Contributor Checklist
- [x] Which branch are you merging into?
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
