### PR TITLE
fix(aws-secrets): use AWS secrets only if enabled

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -235,14 +235,6 @@ spec:
             - name: CONCOURSE_SECRET_CACHE_PURGE_INTERVAL
               value: {{ .Values.concourse.web.secretCachePurgeInterval | quote }}
             {{- end }}
-            {{- if .Values.concourse.web.awsSecretsManager.region }}
-            - name: CONCOURSE_AWS_SECRETSMANAGER_REGION
-              value: {{ .Values.concourse.web.awsSecretsManager.region | quote }}
-            {{- end }}
-            {{- if .Values.concourse.web.awsSsm.region }}
-            - name: CONCOURSE_AWS_SSM_REGION
-              value: {{ .Values.concourse.web.awsSsm.region | quote }}
-            {{- end }}
             {{- if .Values.concourse.web.tracing.serviceName }}
             - name: CONCOURSE_TRACING_SERVICE_NAME
               value: {{ .Values.concourse.web.tracing.serviceName | quote }}
@@ -536,6 +528,10 @@ spec:
             - name: CONCOURSE_AWS_SECRETSMANAGER_PIPELINE_SECRET_TEMPLATE
               value: {{ .Values.concourse.web.awsSecretsManager.pipelineSecretTemplate | quote }}
             {{- end }}
+            {{- if .Values.concourse.web.awsSecretsManager.region }}
+            - name: CONCOURSE_AWS_SECRETSMANAGER_REGION
+              value: {{ .Values.concourse.web.awsSecretsManager.region | quote }}
+            {{- end }}
             {{- if .Values.concourse.web.awsSecretsManager.teamSecretTemplate }}
             - name: CONCOURSE_AWS_SECRETSMANAGER_TEAM_SECRET_TEMPLATE
               value: {{ .Values.concourse.web.awsSecretsManager.teamSecretTemplate | quote }}
@@ -568,6 +564,10 @@ spec:
             {{- if .Values.concourse.web.awsSsm.pipelineSecretTemplate }}
             - name: CONCOURSE_AWS_SSM_PIPELINE_SECRET_TEMPLATE
               value: {{ .Values.concourse.web.awsSsm.pipelineSecretTemplate | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.awsSsm.region }}
+            - name: CONCOURSE_AWS_SSM_REGION
+              value: {{ .Values.concourse.web.awsSsm.region | quote }}
             {{- end }}
             {{- if .Values.concourse.web.awsSsm.teamSecretTemplate }}
             - name: CONCOURSE_AWS_SSM_TEAM_SECRET_TEMPLATE


### PR DESCRIPTION
Only set the AWS variables if the enabled flag is true for secrets lookup

# Existing Issue
Fixes #348.

# Changes proposed in this pull request
* only set AWS region variable if AWS Secrets Manager or Ssm integration is enabled 

# Reviewer Checklist
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
