### PR TITLE
Replace deprecated `.Capabilities.KubeVersion.GitVersion` references

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Creates the address of the TSA service.
 Determine version of Kubernetes cluster
 */}}
 {{- define "concourse.kubeVersion" -}}
-{{- print (.Capabilities.KubeVersion.GitVersion | replace "v" "") -}}
+{{- print (.Capabilities.KubeVersion.Version | replace "v" "") -}}
 {{- end -}}
 
 {{/*

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -171,7 +171,7 @@ spec:
               - key: worker-additional-certs
                 path: worker-additional-certs.pem
         {{- end }}
-      {{- if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion }}
+      {{- if semverCompare "^1.7-0" .Capabilities.KubeVersion.Version }}
   strategy:
 {{ toYaml .Values.worker.updateStrategy | indent 4 }}
       {{- end }}

--- a/templates/worker-horizontal-pod-autoscaler.yaml
+++ b/templates/worker-horizontal-pod-autoscaler.yaml
@@ -1,6 +1,6 @@
 {{- if  .Values.concourse.worker.autoscaling }}
   {{- if .Values.concourse.worker.autoscaling.maxReplicas }}
-{{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: autoscaling/v2
 {{- else -}}
 apiVersion: autoscaling/v2beta2

--- a/templates/worker-policy.yaml
+++ b/templates/worker-policy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.worker.enabled -}}
-{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: policy/v1
 {{- else -}}
 apiVersion: policy/v1beta1

--- a/templates/worker-statefulset.yaml
+++ b/templates/worker-statefulset.yaml
@@ -231,7 +231,7 @@ spec:
             {{- end }}
       {{- end }}
   {{- end }}
-  {{- if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion }}
+  {{- if semverCompare "^1.7-0" .Capabilities.KubeVersion.Version }}
   updateStrategy:
 {{ toYaml .Values.worker.updateStrategy | indent 4 }}
   {{- end }}


### PR DESCRIPTION
> Deprecated: use KubeVersion.Version
https://github.com/helm/helm/blob/82195652495d757d87c1a01f640973f20ca141b0/pkg/chartutil/capabilities.go#L82-L83

<!--
Hi there! Thanks for submitting a pull request to the Concourse Helm chart!
If you haven't already, please take a look at our [Code of Conduct](https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md).

To help us review your PR, please fill in the following information.
Feel free to delete any sections not applicable to your pull request.
-->

# Existing Issue
<!--
Is there an existing issue related to this PR? Fill in the issue number as follows: Fixes #1234.
-->

No, I was just confused by the deprecated references while reading the chart

# Why do we need this PR?
<!--
No issue number? Please give us a few lines of context describing the need for this PR.
-->

Just to remove a use of deprecated helm-builtin


# Changes proposed in this pull request
<!--
What are the changes included in this PR? Feel free to add as many lines as needed below.
-->

* `s/.Capabilities.KubeVersion.GitVersion/.Capabilities.KubeVersion.Version/`

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [ ] Variables are documented in the `README.md`
- [x] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
