### PR TITLE
Add containerd IPv6 env vars

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -296,6 +296,18 @@ Return concourse environment variables for worker configuration
 - name: CONCOURSE_CONTAINERD_NETWORK_POOL
   value: {{ .Values.concourse.worker.containerd.networkPool | quote }}
 {{- end }}
+{{- if .Values.concourse.worker.containerd.ipv6.enabled }}
+- name: CONCOURSE_CONTAINERD_V6_ENABLE
+  value: {{ .Values.concourse.worker.containerd.ipv6.enabled | quote }}
+{{- end }}
+{{- if .Values.concourse.worker.containerd.ipv6.pool }}
+- name: CONCOURSE_CONTAINERD_V6_POOL
+  value: {{ .Values.concourse.worker.containerd.ipv6.pool | quote }}
+{{- end }}
+{{- if .Values.concourse.worker.containerd.ipv6.disableMasquerade }}
+- name: CONCOURSE_CONTAINERD_V6_DISABLE_MASQUERADE
+  value: {{ .Values.concourse.worker.containerd.ipv6.disableMasquerade | quote }}
+{{- end }}
 {{- if .Values.concourse.worker.containerd.requestTimeout }}
 - name: CONCOURSE_CONTAINERD_REQUEST_TIMEOUT
   value: {{ .Values.concourse.worker.containerd.requestTimeout | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -1799,9 +1799,22 @@ concourse:
       ## Maximum container capacity. 0 means no limit. Defaults to 250.
       maxContainers:
 
-      ## Network range to use for dynamically allocated container subnets, defaults to "10.80.0.0/16"
-      ##
+      ## Network range to use for dynamically allocated container subnets
+      ## defaults to "10.80.0.0/16"
       networkPool:
+
+      ## Enable and configure IPv6 for containers on the worker
+      ipv6:
+
+        ## Enables IPv6 networking in the Containerd CNI
+        enabled: false
+
+        ## Network range to use for dynamically allocated container
+        ## subnets, defaults to "fd9c:31a6:c759::/64"
+        pool:
+
+        ## Disables masquerading of container traffic with the workers address
+        disableMasquerade:
 
       ## Time to wait for requests to Containerd to complete. 0 means no timeout.
       requestTimeout:


### PR DESCRIPTION
# Why do we need this PR?
Adding env vars from https://github.com/concourse/concourse/pull/8801

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [ ] ~Variables are documented in the `README.md`~ Not applicable for env vars
- [x] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] ~Back-port if needed~
- [x] Is the correct branch targeted? (`master` or `dev`)
