### PR TITLE
fix: remove defaultMode for mounted volumes

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -1579,7 +1579,6 @@ spec:
         - name: concourse-keys
           secret:
             secretName: {{ template "concourse.web.fullname" . }}
-            defaultMode: 0400
             items:
               - key: host-key
                 path: host_key
@@ -1591,7 +1590,6 @@ spec:
         - name: team-authorized-keys
           secret:
             secretName: {{ template "concourse.web.fullname" . }}
-            defaultMode: 0400
             items:
             {{- range .Values.secrets.teamAuthorizedKeys }}
             - key: {{ .team }}-team-authorized-key
@@ -1603,7 +1601,6 @@ spec:
         - name: web-tls
           secret:
             secretName: {{ template "concourse.web.fullname" . }}
-            defaultMode: 0400
             items:
               - key: web-tls-cert
                 path: client.cert
@@ -1619,7 +1616,6 @@ spec:
         - name: vault-keys
           secret:
             secretName: {{ template "concourse.web.fullname" . }}
-            defaultMode: 0400
             items:
             {{- if .Values.concourse.web.vault.useCaCert }}
               - key: vault-ca-cert
@@ -1636,7 +1632,6 @@ spec:
         - name: credhub-keys
           secret:
             secretName: {{ template "concourse.web.fullname" . }}
-            defaultMode: 0400
             items:
             {{- if .Values.concourse.web.credhub.useCaCert }}
               - key: credhub-ca-cert
@@ -1647,7 +1642,6 @@ spec:
         - name: conjur-keys
           secret:
             secretName: {{ template "concourse.web.fullname" . }}
-            defaultMode: 0400
             items:
             {{- if .Values.secrets.conjurCACert }}
               - key: conjur-ca-cert
@@ -1658,7 +1652,6 @@ spec:
         - name: postgresql-keys
           secret:
             secretName: {{ template "concourse.web.fullname" . }}
-            defaultMode: 0400
             items:
               - key: postgresql-ca-cert
                 path: ca.cert
@@ -1671,7 +1664,6 @@ spec:
         - name: syslog-keys
           secret:
             secretName: {{ template "concourse.web.fullname" . }}
-            defaultMode: 0400
             items:
               - key: syslog-ca-cert
                 path: ca.cert
@@ -1684,7 +1676,6 @@ spec:
         - name: auth-keys
           secret:
             secretName: {{ template "concourse.web.fullname" . }}
-            defaultMode: 0400
             items:
               {{- if .Values.concourse.web.auth.cf.useCaCert }}
               - key: cf-ca-cert


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to the Concourse Helm chart!
If you haven't already, please take a look at our [Code of Conduct](https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md).

To help us review your PR, please fill in the following information.
Feel free to delete any sections not applicable to your pull request.
-->

# Existing Issue

None currently

# Why do we need this PR?
<!--
No issue number? Please give us a few lines of context describing the need for this PR.
-->
Concourse currently requires to run as root in kubernetes, this boils down to `defaultMode` being forced on via the helm template, as if you change the uid/gid to anything other than 0:0 (root) it cannot be read.

# Changes proposed in this pull request
<!--
What are the changes included in this PR? Feel free to add as many lines as needed below.
-->

* Remove `defaultMode` from the web deployment to allow Concourse to run in a secure way in kubernetes

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [X] Variables are documented in the `README.md`
- [X] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
