### PR TITLE
fix downgraded PostgreSQL chart version

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.9.8
-digest: sha256:2ade0110105c9a1cb864c813473cdbfddb4eee4c9bbf79dee9a4da90fe82bb44
-generated: "2022-10-08T15:03:27.191417208Z"
+  version: 12.12.10
+digest: sha256:4ecfc1482bfb75529b0fda44b37bda7dd39f178990c1fc348eb18d9ca352e1df
+generated: "2024-01-26T16:58:47.45980195Z"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ sources:
   - https://github.com/concourse/concourse
 dependencies:
   - name: postgresql
-    version: 11.9.8
+    version: 12.12.10
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
 maintainers:


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to the Concourse Helm chart!
If you haven't already, please take a look at our [Code of Conduct](https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md).

To help us review your PR, please fill in the following information.
Feel free to delete any sections not applicable to your pull request.
-->

# Existing Issue
<!--
Is there an existing issue related to this PR? Fill in the issue number as follows: Fixes #1234.
-->

Fixes #367 .

# Why do we need this PR?
<!--
No issue number? Please give us a few lines of context describing the need for this PR.
-->

PostgreSQL version accidentally downgraded in most recent release. This breaks upgrades to existing installations.

# Changes proposed in this pull request
<!--
What are the changes included in this PR? Feel free to add as many lines as needed below.
-->

* This fixes the accidental downgrade of the PostgreSQL chart (and with it the PostgreSQL version) introduced in the `v17.4.0` release. 

# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [ ] Which branch are you merging into?
    - tbh I don't really understand to which branch this change should be merged. `master` and `dev` do not reflect the state in `release/7.12.x`. The release `v.17.4.0` which introduced the issue is drafted from `release/7.12.x` to which I pointed this PR. Please advice if this needs to changed. 

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
