### PR TITLE
Allow worker.*.maxContainers to be 0

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -244,7 +244,7 @@ Return concourse environment variables for worker configuration
 - name: CONCOURSE_GARDEN_REQUEST_TIMEOUT
   value: {{ .Values.concourse.worker.garden.requestTimeout | quote }}
 {{- end }}
-{{- if .Values.concourse.worker.garden.maxContainers }}
+{{- if .Values.concourse.worker.garden.maxContainers | ne nil }}
 - name: CONCOURSE_GARDEN_MAX_CONTAINERS
   value: {{ .Values.concourse.worker.garden.maxContainers | quote }}
 {{- end }}
@@ -288,7 +288,7 @@ Return concourse environment variables for worker configuration
 - name: CONCOURSE_CONTAINERD_ALLOW_HOST_ACCESS
   value: {{ .Values.concourse.worker.containerd.allowHostAccess | quote }}
 {{- end }}
-{{- if .Values.concourse.worker.containerd.maxContainers }}
+{{- if .Values.concourse.worker.containerd.maxContainers | ne nil }}
 - name: CONCOURSE_CONTAINERD_MAX_CONTAINERS
   value: {{ .Values.concourse.worker.containerd.maxContainers | quote }}
 {{- end }}


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to the Concourse Helm chart!
If you haven't already, please take a look at our [Code of Conduct](https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md).

To help us review your PR, please fill in the following information.
Feel free to delete any sections not applicable to your pull request.
-->

# Why do we need this PR?

worker.*.maxContainers documentation states it's 250 by default, and 0 is unlimited. However, setting it to 0 makes the template skip the env var, thus taking its default value.

# Changes proposed in this pull request

Take into account that they can be to set 0.

# Contributor Checklist

- [X] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
