### PR TITLE
Additonal hosts support in Concourse Helm Chart

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -284,6 +284,12 @@ Return concourse environment variables for worker configuration
   value: {{ . | title | quote }}
 {{- end }}
 {{- end }}
+{{- if .Values.concourse.worker.containerd.additionalHosts }}
+{{- range .Values.concourse.worker.containerd.additionalHosts }}
+- name: CONCOURSE_CONTAINERD_ADDITIONAL_HOSTS
+  value: {{ . | title | quote }}
+{{- end }}
+{{- end }}
 {{- if .Values.concourse.worker.containerd.allowHostAccess }}
 - name: CONCOURSE_CONTAINERD_ALLOW_HOST_ACCESS
   value: {{ .Values.concourse.worker.containerd.allowHostAccess | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -1798,6 +1798,13 @@ concourse:
       ##   - 2.2.2.2
       restrictedNetworks: []
 
+      ## List of hosts to be added to /etc/hosts file.
+      ## Example:
+      ## additionalHosts:
+      ##   - 1.1.1.1 example.com
+      ##   - 2.2.2.2 another.example.com
+      additionalHosts: []
+
       ## Allows containers to reach host network.
       allowHostAccess:
 


### PR DESCRIPTION
# Why do we need this PR?
Because of upstream change - https://github.com/concourse/concourse/pull/9238


# Changes proposed in this pull request
*  support for additional dns hosts in `/etc/hosts` of the container when using `containerd` runtime.


# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [ ] Variables are documented in the `README.md` - None of the `containerd` ones are documented, so not sure if this PR should address that
- [ ] Which branch are you merging into? - `dev`, until PR on upstream is merged I guess
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
