### PR TITLE
Create emptyDir for worker when using kind Deployment

### DIFF
--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -116,6 +116,10 @@ spec:
               subPath: worker-additional-certs.pem
               readOnly: true
             {{- end }}
+            {{- if include "concourse.are-there-additional-volumes.with-the-name.concourse-work-dir" . | not }}
+            - name: concourse-work-dir
+              mountPath: {{ .Values.concourse.worker.workDir | quote }}
+            {{- end }}
 
 {{- if .Values.worker.additionalVolumeMounts }}
 {{ toYaml .Values.worker.additionalVolumeMounts | indent 12 }}
@@ -147,6 +151,13 @@ spec:
                   release: {{ .Release.Name | quote }}
           {{- end }}
       volumes:
+      {{- if include "concourse.are-there-additional-volumes.with-the-name.concourse-work-dir" . | not }}
+        - name: concourse-work-dir
+          emptyDir:
+            {{- if .Values.worker.emptyDirSize }}
+            sizeLimit: {{ .Values.worker.emptyDirSize | quote }}
+            {{- end }}
+      {{- end }}
 {{- if .Values.worker.additionalVolumes }}
 {{ toYaml .Values.worker.additionalVolumes | indent 8 }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -2683,7 +2683,8 @@ worker:
   ## Ignored for Kind Deployment
   podManagementPolicy: Parallel
 
-  ## When persistance is disabled this value will be used to limit the emptyDir volume size
+  ## When persistance is disabled or using a Deployment, this value will be used
+  ## to limit the emptyDir volume size
   ## Ref: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir
   ##
   ## Example: 20Gi


### PR DESCRIPTION
# Existing Issue

Fixes #255

# Why do we need this PR?

It seems the root container volume is read-only, so we can't write whatever we want to it anymore. Resolved by copying what we do in the StatefulSet and creating an emptyDir volume for the work dir. If someone is already using the workaround from #255, this change won't break anything for them, it'll skip creating the emptyDir.

# Contributor Checklist

- [x] Variables are documented in the `README.md`
- [x] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
