### PR TITLE
Remove extra quotes from CONCOURSE_VAULT_CLIENT_TOKEN_PATH

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -623,7 +623,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.vault.tokenPath }}
             - name: CONCOURSE_VAULT_CLIENT_TOKEN_PATH
-              value: "{{ .Values.concourse.web.vault.tokenPath | quote }}"
+              value: {{ .Values.concourse.web.vault.tokenPath | quote }}
             {{- end }}
             {{- if eq .Values.concourse.web.vault.authBackend "cert" }}
             - name: CONCOURSE_VAULT_CLIENT_CERT


### PR DESCRIPTION
# Why do we need this PR?
When specifying `concourse.web.vault.tokenPath`, the `web-deployment.yaml` template incorrectly passes the variable into `quote`, then quotes it again, producing invalid YAML. This change removes the double quotes to produce valid YAML.

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
