### PR TITLE
Configuration options for the PostgreSQL and concourseMigration

### DIFF
--- a/templates/postgres-statefulset.yaml
+++ b/templates/postgres-statefulset.yaml
@@ -24,6 +24,21 @@ spec:
       labels:
         app: "{{ template "concourse.postgresql.fullname" . }}"
     spec:
+    {{- if .Values.postgresql.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.postgresql.nodeSelector | indent 8 }}
+    {{- end }}
+      serviceAccountName: "{{ .Values.rbac.postgresqlServiceAccountName }}"
+      {{- if .Values.postgresql.tolerations }}
+      tolerations:
+{{ toYaml .Values.postgresql.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
       - name: "{{ template "concourse.postgresql.fullname" . }}"
         {{- if .Values.postgresql.imageDigest }}

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -69,6 +69,10 @@ spec:
           securityContext:
           {{- toYaml .Values.web.securityContext | nindent 12 }}
           {{- end }}
+{{- if .Values.web.concourseMigration.resources }}
+          resources:
+{{ toYaml .Values.web.concourseMigration.resources | indent 12 }}
+{{- end }}
           env:
 {{- include "concourse.postgresql.env" . | indent 12 }}
           volumeMounts:

--- a/values.yaml
+++ b/values.yaml
@@ -2098,6 +2098,13 @@ web:
   ##
   databaseInitContainers: []
 
+  ## Configuration values for InitContainer that runs Concourse database migrations
+  concourseMigration:
+    ## Configure resource requests and limits.
+    ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+    ##
+    resources: {}
+
   ## Array of extra initContainers to run before Concourse Web starts
   ## container.
   ##
@@ -2878,6 +2885,14 @@ postgresql:
       ephemeral-storage: 2Gi
       memory: 512Mi
 
+  ## Tolerations for the postgresql.
+  tolerations: []
+
+  ## Node selector for the postgresql.
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  ##
+  nodeSelector: {}
+
   ## Setup postgresql auth info, will be fed to concourse
   ## Those will be given to postgres using the standard env vars
   ## POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB
@@ -2984,6 +2999,10 @@ rbac:
 
   ## Any annotations required for the worker Service Account
   workerServiceAccountAnnotations: {}
+
+  ## The name of the service account to use for postgresql pods if rbac.create is false
+  ##
+  postgresqlServiceAccountName: default
 
 ## For managing podSecurityPolicies. To make sure rbac objects are also created
 ## for the use of the podsecuritypolicy objects,


### PR DESCRIPTION
Support deployment on restrictive Kubernetes clusters that enforce security policies like resource limits and private registry access.

The patch introduces additional configuration options for the PostgreSQL component
* nodeSelector: `.Values.postgresql.nodeSelector`
* serviceAccountName: `.Values.postgresql.serviceAccountName`
* tolerations: `.Values.postgresql.tolerations`
* imagePullSecrets: from the global `.Values.imagePullSecrets`

Also introduce a new field concourseMigration for the Concourse DB migration init container configuration
* resources: `.Values.web.concourseMigration.resources`