### PR TITLE
remove engine key from Chart.yaml

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -16,4 +16,3 @@ sources:
 maintainers:
   - name: concourse-team
     email: team@concourse-ci.org
-engine: gotpl


### PR DESCRIPTION
remove engine key from Chart.yaml. Was seeing this when installing the chart:

```
[WARNING] Chart.yaml: failed to strictly parse chart metadata file
        error unmarshaling JSON: while decoding JSON: json: unknown field "engine"
```