### PR TITLE
fix: use `gitea` value for GITEA_TEAM

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -1107,7 +1107,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.auth.mainTeam.gitea.team }}
             - name: CONCOURSE_MAIN_TEAM_GITEA_TEAM
-              value: {{ .Values.concourse.web.auth.mainTeam.github.team | quote }}
+              value: {{ .Values.concourse.web.auth.mainTeam.gitea.team | quote }}
             {{- end }}
             {{- if .Values.concourse.web.auth.mainTeam.ldap.user }}
             - name: CONCOURSE_MAIN_TEAM_LDAP_USER

--- a/values.yaml
+++ b/values.yaml
@@ -3331,7 +3331,7 @@ secrets:
   postgresClientCert:
   postgresClientKey:
 
-  ## Pasphrase for DB encryption. A 16 or 32 byte key that will be used to
+  ## Passphrase for DB encryption. A 16 or 32 byte key that will be used to
   ## generate an AES key to encrypt sensitive data in the DB.
   ##
   encryptionKey:


### PR DESCRIPTION
# Existing Issue

n/a

# Why do we need this PR?

There is the wrong value referenced for `CONCOURSE_MAIN_TEAM_GITEA_TEAM`, it looks to be a copy-paste error. Also fixed a minor typo I came across, hope it's fine to do it in this PR :)

# Changes proposed in this pull request

- Update the value to use the correct `gitea.team`
- Fixed small typo (`Pasphrase` -> `Passphrase`)

# Contributor Checklist

- ~~Variables are documented in the `README.md`~~ n/a
- [x] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - ~~`dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))~~


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
