### PR TITLE
add CONCOURSE_STALLED_WORKER_TIMEOUT to web

### DIFF
--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -437,6 +437,10 @@ spec:
             - name: CONCOURSE_P2P_VOLUME_STREAMING_TIMEOUT
               value: {{ .Values.concourse.web.p2pVolumeStreamingTimeout | quote }}
             {{- end }}
+            {{- if .Values.concourse.web.stalledWorkerTimeout }}
+            - name: CONCOURSE_STALLED_WORKER_TIMEOUT
+              value: {{ .Values.concourse.web.stalledWorkerTimeout | quote }}
+            {{- end }}
             {{- if .Values.concourse.web.maxChecksPerSecond }}
             - name: CONCOURSE_MAX_CHECKS_PER_SECOND
               value: {{ .Values.concourse.web.maxChecksPerSecond | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -317,6 +317,13 @@ concourse:
     ##
     p2pVolumeStreamingTimeout:
 
+    ## Period after which stalled (unresponsive, non-ephemeral) workers will be
+    ## automatically pruned along with their cache state. 0s (the default) means
+    ## stalled workers are never automatically pruned and must be removed manually
+    ## with 'fly prune-worker'.
+    ##
+    stalledWorkerTimeout:
+
     ## Maximum number of checks that can be started per second. If not
     ## specified, # this will be calculated as (# of resources)/(resource
     ## checking interval). # -1 value will remove this maximum limit of checks


### PR DESCRIPTION
# Why do we need this PR?
Added in https://github.com/concourse/concourse/pull/9604


# Contributor Checklist
<!--
Are the following items included as part of this PR? Please delete checkbox items that don't apply.
-->
- [ ] Variables are documented in the `README.md`
- [x] Which branch are you merging into?
    - `master` is for changes related to the current release of the `concourse/concourse:latest` image and should be good to publish immediately
    - `dev` is for changes related to the next release of Concourse (aka unpublished code on `master` in [concourse/concourse](https://github.com/concourse/concourse))


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Topgun tests run
- [ ] Back-port if needed
- [ ] Is the correct branch targeted? (`master` or `dev`)
