### PR TITLE
Add resource requests/limits support for worker init-rm container

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `worker.annotations` | Annotations to be added to the worker pods | `{}` |
 | `worker.autoscaling` | Enable and configure pod autoscaling | `{}` |
 | `worker.cleanUpWorkDirOnStart` | Removes any previous state created in `concourse.worker.workDir` | `true` |
+| `worker.initRM.resources` | Resource requests/limits for the init-rm init container | `{}` |
 | `worker.emptyDirSize` | When persistance is disabled this value will be used to limit the emptyDir volume size | `nil` |
 | `worker.enabled` | Enable or disable the worker component. You should set postgres.enabled=false in order not to get an unnecessary Postgres chart deployed | `true` |
 | `worker.env` | Configure additional environment variables for the worker container(s) | `[]` |

--- a/templates/worker-statefulset.yaml
+++ b/templates/worker-statefulset.yaml
@@ -70,6 +70,12 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
           securityContext:
             privileged: true
+          {{- if .Values.worker.initRM }}
+          {{- if .Values.worker.initRM.resources }}
+          resources:
+            {{- toYaml .Values.worker.initRM.resources | nindent 12 }}
+          {{- end }}
+          {{- end }}
           command:
             - /bin/bash
           args:

--- a/values.yaml
+++ b/values.yaml
@@ -2612,6 +2612,23 @@ worker:
   ##
   cleanUpWorkDirOnStart: true
 
+  ## Configuration for the init-rm init container that cleans up the work dir.
+  ##
+  initRM:
+    ## Resource requests/limits for the init-rm init container.
+    ## Required on OpenShift or clusters with LimitRange/ResourceQuota enforcement.
+    ##
+    ## Example:
+    ## resources:
+    ##   requests:
+    ##     cpu: 100m
+    ##     memory: 128Mi
+    ##   limits:
+    ##     cpu: 200m
+    ##     memory: 256Mi
+    ##
+    resources: {}
+
   ## Number of replicas.
   ##
   replicas: 2


### PR DESCRIPTION
Why do we need this PR?

On OpenShift or clusters with LimitRange/ResourceQuota enforcement, all containers must have resource requests and limits defined. The init-rm init container previously had no way to set these via values.yaml, causing pod
admission failures.

Changes proposed in this pull request

- Add worker.initRM.resources to allow configuring requests/limits on the init-rm init container
- Follow the same pattern as the existing web.concourseMigration.resources
- Document the new parameter in README.md

Contributor Checklist

- [x] Variables are documented in the README.md
- [x] Which branch are you merging into?
    - master — this is a fix for the current release